### PR TITLE
chore(docs): change ionic to cordova in commands

### DIFF
--- a/scripts/docs/templates/common.template.html
+++ b/scripts/docs/templates/common.template.html
@@ -117,7 +117,7 @@ Improve this doc
 <!-- decorators -->
 <@- if doc.decorators @>
 <@ for prop in doc.decorators[0].argumentInfo @>
-<pre><code>$ ionic plugin add <$ prop.plugin $></code></pre>
+<pre><code>$ cordova plugin add <$ prop.plugin $></code></pre>
 <p>Repo:
 <a href="<$ prop.repo $>">
 <$ prop.repo $>


### PR DESCRIPTION
Shouldn't we use `cordova` instead of `ionic` in case of non-IonicCLI users trying to use Ionic Native?