### PR TITLE
Show import format and link to ionic-native

### DIFF
--- a/src/plugins/camera.ts
+++ b/src/plugins/camera.ts
@@ -89,10 +89,12 @@ export interface CameraPopoverOptions {
  * @description
  * Take a photo or capture video.
  *
- * Requires Cordova plugin: `cordova-plugin-camera`. For more info, please see the [Cordova Camera Plugin Docs](https://github.com/apache/cordova-plugin-camera).
+ * Requires {@link module:driftyco/ionic-native} and the Cordova plugin: `cordova-plugin-camera`. For more info, please see the [Cordova Camera Plugin Docs](https://github.com/apache/cordova-plugin-camera).
  *
  * @usage
  * ```js
+ * import {Camera} from 'ionic-native';
+ * 
  * Camera.getPicture(options).then((imageData) => {
  *  // imageData is either a base64 encoded string or a file URI
  *  // If it's base64:


### PR DESCRIPTION
The plugin docs should mention ionic-native and the required import format, which we only found in https://forum.ionicframework.com/t/camera-plugin-not-working-build-error/45004/4?u=jonrsharpe after searching for quite a while.