### PR TITLE
docs(toast): Add import statement for Toast

### DIFF
--- a/src/plugins/toast.ts
+++ b/src/plugins/toast.ts
@@ -16,6 +16,8 @@ export interface ToastOptions {
  *
  * @usage
  * ```ts
+ * import {Toast} from 'ionic-native';
+ * 
  * Toast.show("I'm a toast", 5000, "center").subscribe(
  *   toast => {
  *     console.log(toast);


### PR DESCRIPTION
Makes it clear how to import the Toast component into projects.