### PR TITLE
Append Trailing Slash If Not Present On path Param

### DIFF
--- a/src/plugins/file.ts
+++ b/src/plugins/file.ts
@@ -50,7 +50,11 @@ export class File {
     if ((/^\//.test(dir))) {
       rejectFn('directory cannot start with \/');
     }
-
+    
+    if (!(/\/$/.test(noSlash))) {
+      path += "/";
+    }
+    
     try {
       var directory = path + dir;
 
@@ -351,6 +355,10 @@ export class File {
       rejectFn('file cannot start with \/');
     }
 
+    if (!(/\/$/.test(noSlash))) {
+      path += "/";
+    }
+    
     try {
       var directory = path + file;
 


### PR DESCRIPTION
This minor addition will automatically append a trailing slash ```/``` when the path param does not end with a slash and is used to build a directory path via concatenation.