### PR TITLE
Correct battery-status "status" event name

### DIFF
--- a/src/plugins/batterystatus.ts
+++ b/src/plugins/batterystatus.ts
@@ -37,7 +37,7 @@ export class BatteryStatus {
    */
   @Cordova({
     eventObservable: true,
-    event: 'batterylevel'
+    event: 'batterystatus'
   })
   static onChange () : Observable<StatusObject> {return}
 


### PR DESCRIPTION
As seen in the [plugin documentation](https://github.com/apache/cordova-plugin-battery-status#batterystatus-event) the event used should be called "batterystatus" instead of "batterylevel". Currently the observable you provide in the onChange method never fires, beacuse it's listening to a wrong event. This pull request aims to fix that.