### PR TITLE
Add DeviceAccounts plugin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {Contacts} from './plugins/contacts';
 import {DatePicker} from './plugins/datepicker';
 import {DBMeter} from './plugins/dbmeter';
 import {Device} from './plugins/device';
+import {DeviceAccounts} from './plugins/deviceaccounts';
 import {DeviceMotion} from './plugins/devicemotion';
 import {DeviceOrientation} from './plugins/deviceorientation';
 import {Diagnostic} from './plugins/diagnostic';
@@ -66,6 +67,7 @@ export {
   DatePicker,
   DBMeter,
   Device,
+  DeviceAccounts,
   DeviceMotion,
   DeviceOrientation,
   Dialogs,
@@ -115,6 +117,7 @@ window['IonicNative'] = {
   DatePicker: DatePicker,
   DBMeter: DBMeter,
   Device: Device,
+  DeviceAccounts: DeviceAccounts,
   DeviceMotion: DeviceMotion,
   DeviceOrientation: DeviceOrientation,
   Dialogs: Dialogs,

--- a/src/plugins/deviceaccounts.ts
+++ b/src/plugins/deviceaccounts.ts
@@ -1,0 +1,33 @@
+import {Cordova, Plugin} from './plugin';
+declare var window;
+@Plugin({
+  plugin: 'https://github.com/loicknuchel/cordova-device-accounts.git',
+  pluginRef: 'plugins.DeviceAccounts',
+  repo: 'https://github.com/loicknuchel/cordova-device-accounts.git'
+})
+export class DeviceAccounts {
+
+/**
+ *  Gets all accounts registered on the Android Device
+ */
+  @Cordova()
+  static get() : Promise<any> {return}
+
+/**
+ *  Get all accounts registred on Android device for requested type
+ */
+  @Cordova()
+  static getByType(type: string) : Promise<any> {return}
+
+/**
+ *  Get all emails registred on Android device (accounts with 'com.google' type)
+ */
+  @Cordova()
+  static getEmails() : Promise<any> {return}
+
+/**
+ *  Get the first email registred on Android device
+ */
+  @Cordova()
+  static getEmail() : Promise<any> {return}
+}


### PR DESCRIPTION
Adds Device Accounts Cordova plugin (https://github.com/loicknuchel/cordova-device-accounts) 

Requires the android.permission.GET_ACCOUNTS permission

Issue: https://github.com/driftyco/ionic-native/issues/140
