### PR TITLE
type return value of globalization's stringToNumber

### DIFF
--- a/src/plugins/globalization.ts
+++ b/src/plugins/globalization.ts
@@ -107,7 +107,7 @@ export class Globalization {
     successIndex:  1,
     errorIndex:  2
   })
-  static stringToNumber(stringToConvert: string, options: {type: string}): Promise<{value}> {return; }
+  static stringToNumber(stringToConvert: string, options: {type: string}): Promise<{value:number|string}> {return; }
 
   /**
    *


### PR DESCRIPTION
This allows client code to compile properly when TypeScript's `noImplicitAny` is enabled.