### PR TITLE
Implemented wrapper for display brightness control

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {BackgroundMode} from './plugins/backgroundmode';
 import {BarcodeScanner} from './plugins/barcodescanner';
 import {Base64ToGallery} from './plugins/base64togallery';
 import {BatteryStatus} from './plugins/batterystatus';
+import {Brightness} from './plugins/brightness';
 import {BLE} from './plugins/ble';
 import {BluetoothSerial} from './plugins/bluetoothserial';
 import {Calendar} from './plugins/calendar';
@@ -99,6 +100,7 @@ export {
   BarcodeScanner,
   Base64ToGallery,
   BatteryStatus,
+  Brightness,
   BLE,
   BluetoothSerial,
   Clipboard,
@@ -145,6 +147,7 @@ window['IonicNative'] = {
   BarcodeScanner: BarcodeScanner,
   Base64ToGallery: Base64ToGallery,
   BatteryStatus: BatteryStatus,
+  Brightness: Brightness,
   BLE: BLE,
   BluetoothSerial: BluetoothSerial,
   Calendar: Calendar,

--- a/src/plugins/brightness.ts
+++ b/src/plugins/brightness.ts
@@ -31,11 +31,4 @@ export class Brightness {
     */
     @Cordova()
     static setKeepScreenOn(value: boolean): void { }
-
-
-    /**
-     * Hide the ActionSheet.
-     */
-    @Cordova()
-    static hide(): Promise<any> { return; }
 }

--- a/src/plugins/brightness.ts
+++ b/src/plugins/brightness.ts
@@ -1,0 +1,41 @@
+import {Plugin, Cordova} from './plugin';
+
+@Plugin({
+    plugin: 'cordova-plugin-brightness',
+    pluginRef: 'plugins.brightness',
+    repo: 'https://github.com/mgcrea/cordova-plugin-brightness',
+    platforms: ['Android', 'iOS']
+})
+export class Brightness {
+
+    /**
+     * Sets the brightness of the display.
+     *
+     * @param {value} Floating number between 0 and 1 in which case 1 means 100% brightness and 0 means 0% brightness.
+     * @returns {Promise} Returns a Promise that resolves if setting brightness was successful.
+     */
+    @Cordova()
+    static setBrightness(value: number): Promise<any> { return; }
+
+    /**
+     * Reads the current brightness of the device display.
+     *
+     * @returns {Promise} Returns a Promise that resolves with the 
+     * brightness value of the device display (floating number between 0 and 1).
+     */
+    @Cordova()
+    static getBrightness(): Promise<any> { return; }
+
+    /**
+    * Keeps the screen on. Prevents the device from setting the screen to sleep.
+    */
+    @Cordova()
+    static setKeepScreenOn(value: boolean): void { }
+
+
+    /**
+     * Hide the ActionSheet.
+     */
+    @Cordova()
+    static hide(): Promise<any> { return; }
+}


### PR DESCRIPTION
I've implemented the support for using the [cordova-plugin-brightness](https://github.com/mgcrea/cordova-plugin-brightness) to control the display brightness of your device.

It's working on iOS and Android.