### PR TITLE
SocialSharing: Add recommended `shareWithOptions` method

### DIFF
--- a/src/plugins/socialsharing.ts
+++ b/src/plugins/socialsharing.ts
@@ -34,6 +34,15 @@ export class SocialSharing {
   static share (message?: string, subject?: string, file?: string|Array<string>, url?: string): void {}
 
   /**
+   * Shares using the share sheet with additional options and returns a result object or an error message (requires plugin version 5.1.0+)
+   * @param options {object} The options object with the message, subject, files, url and chooserTitle properties.
+   */
+  @Cordova({
+    platforms: ['iOS', 'Android']
+  })
+  static shareWithOptions (options: { message?: string, subject?: string, file?: string|Array<string>, url?: string, chooserTitle?: string }): Promise<any> {return; }
+
+  /**
    * Checks if you can share via a specific app.
    * @param appName App name or package name. Examples: instagram or com.apple.social.facebook
    */


### PR DESCRIPTION
Starting from version 5.1.0, the SocialSharing plugin docs recommend to use the new method shareWithOptions, that takes an options object instead of the 4 arguments and returns a result object on success and an error message on failure. The result may include the app selected by the user for analytics purposes (currently iOS only).

This is much more convenient for Ionic developers as the current share method doesn't return anything.

This PR implements the shareWithOptions method with types and returns a promise with either a result or an error.

(Original PR is #218)