### PR TITLE
Changed SafariViewController show return type

### DIFF
--- a/src/plugins/safari-view-controller.ts
+++ b/src/plugins/safari-view-controller.ts
@@ -59,7 +59,7 @@ export class SafariViewController {
     @Cordova({
         callbackOrder: 'reverse'
     })
-    static show(options?: SafariViewControllerOptions): void {}
+    static show(options?: SafariViewControllerOptions): Promise<any> {return; }
 
     /**
      * Hides Safari View Controller


### PR DESCRIPTION
Changed it to `Promise<any>` as in the example. Was `void`.