### PR TITLE
Fix usage example mistake for duration type

### DIFF
--- a/src/plugins/toast.ts
+++ b/src/plugins/toast.ts
@@ -47,7 +47,7 @@ export interface ToastOptions {
  *
  *
  *
- * Toast.show("I'm a toast", 5000, "center").subscribe(
+ * Toast.show("I'm a toast", "5000", "center").subscribe(
  *   toast => {
  *     console.log(toast);
  *   }


### PR DESCRIPTION
In the usage example the duration was displayed as a number instead of the actual string parameter.