### PR TITLE
Add support for Action Buttons on IOs with categories

### DIFF
--- a/src/plugins/push.ts
+++ b/src/plugins/push.ts
@@ -186,6 +186,29 @@ export interface IOSPushOptions {
    * **Note**: only usable in conjunction with `senderID`.
    */
   topics?: string[];
+
+  /**
+   * The data required in order to enable Action Buttons for iOS.
+   * Action Buttons on iOS - https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#action-buttons-1
+   */
+  categories?: CategoryArray
+}
+
+export interface CategoryArray {
+  [name: string]: CategoryAction
+}
+
+export interface CategoryAction {
+  yes?: CategoryActionData
+  no?: CategoryActionData
+  maybe?: CategoryActionData
+}
+
+export interface CategoryActionData {
+  callback: string
+  title: string
+  foreground: boolean
+  destructive: boolean
 }
 
 export interface AndroidPushOptions {


### PR DESCRIPTION
Update directly from [DefinitelyTyped phonegap plugin push](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e42fdcf8b754727afbab9e402665bde60b0f0bf1/phonegap-plugin-push/phonegap-plugin-push.d.ts) to match the [specs](https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/PAYLOAD.md#action-buttons-1) of the plugin. 

This allow the use of the action buttons on IOs with typescript projects. 