### PR TITLE
docs(backgroundMode): fix plugin npm ID

### DIFF
--- a/src/plugins/backgroundmode.ts
+++ b/src/plugins/backgroundmode.ts
@@ -26,7 +26,7 @@ import {Plugin, Cordova} from './plugin';
 *
 */
 @Plugin({
-  plugin: 'de.appplant.cordova.plugin.background-mode',
+  plugin: 'cordova-plugin-background-mode',
   pluginRef: 'cordova.plugins.backgroundMode',
   repo: 'https://github.com/katzer/cordova-plugin-background-mode',
   platforms: ['Android', 'iOS', 'Windows Phone 8']


### PR DESCRIPTION
@ihadeed I meant this fix, `de.appplant.cordova.plugin.background-mode` doesn't exist on npm ;)