### PR TITLE
Update spinnerdialog.ts to fix wrong documentation

### DIFF
--- a/src/plugins/spinnerdialog.ts
+++ b/src/plugins/spinnerdialog.ts
@@ -27,7 +27,7 @@ export class SpinnerDialog {
    * Shows the spinner dialog
    * @param title {string} Spinner title (shows on Android only)
    * @param message {string} Spinner message
-   * @param cancelCallback {boolean|function} Set to false to set spinner not cancelable. Or provide a function to call when the user cancels the spinner.
+   * @param cancelCallback {boolean|function} Set to true to set spinner not cancelable. Or provide a function to call when the user cancels the spinner.
    * @param iOSOptions {object} Options for iOS only
    */
   @Cordova({


### PR DESCRIPTION
Just implemented the SpinnerDialog into my app to use with Ionic Deploy.

The cancelCallback still happens when set to "false", when setting it to "true, the cancelCallback doesn't get called and therefore the SpinnerDialog doesn't hide on Android, exactly as expected.