### PR TITLE
Add canShareViaEmail to SocialSharing plugin

### DIFF
--- a/src/plugins/socialsharing.ts
+++ b/src/plugins/socialsharing.ts
@@ -1,35 +1,44 @@
-import { Cordova, Plugin } from './plugin';
-
+import { Cordova, Plugin} from './plugin';
 
 /**
  * @name Social Sharing
  * @description
  * Share text, files, images, and links via social networks, sms, and email.
  * @usage
- * ```js
+ * ```ts
  * import {SocialSharing} from 'ionic-native';
  *
- * ...
- * // TODO add usage info
+ * // Check if sharing via email is supported
+ * SocialSharing.canShareViaEmail().then(() => {
+ *   // Sharing via email is possible
+ * }).catch(() => {
+ *   // Sharing via email is not possible
+ * });
+ *
+ * // Share via email
+ * SocialSharing.shareViaEmail('Body', 'Subject', 'recipient@example.org').then(() => {
+ *   // Success!
+ * }).catch(() => {
+ *   // Error!
+ * });
  * ```
  */
 @Plugin({
   plugin: 'cordova-plugin-x-socialsharing',
-  pluginRef: 'window.plugins.socialsharing',
+  pluginRef: 'plugins.socialsharing',
   repo: 'https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin',
   platforms: ['iOS', 'Android', 'Windows Phone']
 })
 export class SocialSharing {
-
   /**
    * Shares using the share sheet
    * @param message {string} The message you would like to share.
    * @param subject {string} The subject
-   * @param file {string|Array<string>} URL(s) to file(s) or image(s), local path(s) to file(s) or image(s), or base64 data of an image. Only the first file/image will be used on Windows Phone.
+   * @param file {string|string[]} URL(s) to file(s) or image(s), local path(s) to file(s) or image(s), or base64 data of an image. Only the first file/image will be used on Windows Phone.
    * @param url {string} A URL to share
    */
   @Cordova()
-  static share(message?: string, subject?: string, file?: string | Array<string>, url?: string): Promise<any> { return; }
+  static share(message?: string, subject?: string, file?: string|string[], url?: string): Promise<any> { return; }
 
   /**
    * Shares using the share sheet with additional options and returns a result object or an error message (requires plugin version 5.1.0+)
@@ -38,7 +47,7 @@ export class SocialSharing {
   @Cordova({
     platforms: ['iOS', 'Android']
   })
-  static shareWithOptions(options: { message?: string, subject?: string, file?: string | Array<string>, url?: string, chooserTitle?: string }): Promise<any> { return; }
+  static shareWithOptions(options: { message?: string, subject?: string, file?: string|string[], url?: string, chooserTitle?: string }): Promise<any> { return; }
 
   /**
    * Checks if you can share via a specific app.
@@ -128,17 +137,25 @@ export class SocialSharing {
   static shareViaSMS(messge: string, phoneNumber: string): Promise<any> { return; }
 
   /**
-   * Share via Email
-   * @param message {string}
-   * @param subject {string}
-   * @param to {Array<string>}
-   * @param cc {Array<string>}
-   * @param bcc {Array<string>}
-   * @param files {string|Array<string>} URL or local path to file(s) to attach
+   * Checks if you can share via email
    */
   @Cordova({
     platforms: ['iOS', 'Android']
   })
-  static shareViaEmail(message: string, subject: string, to: Array<string>, cc: Array<string>, bcc: Array<string>, files: string | Array<string>): Promise<any> { return; }
+  static canShareViaEmail(): Promise<any> { return; }
+
+  /**
+   * Share via Email
+   * @param message {string}
+   * @param subject {string}
+   * @param to {string[]}
+   * @param cc {string[]}
+   * @param bcc {string[]}
+   * @param files {string|string[]} URL or local path to file(s) to attach
+   */
+  @Cordova({
+    platforms: ['iOS', 'Android']
+  })
+  static shareViaEmail(message: string, subject: string, to: string[], cc: string[] = [], bcc: string[] = [], files: string|string[] = []): Promise<any> { return; }
 
 }

--- a/src/plugins/socialsharing.ts
+++ b/src/plugins/socialsharing.ts
@@ -1,4 +1,4 @@
-import { Cordova, Plugin} from './plugin';
+import { Cordova, Plugin } from './plugin';
 
 /**
  * @name Social Sharing


### PR DESCRIPTION
- Add support for canShareViaEmail
- Make the following parameters in shareViaEmail method optional: cc, bcc, files
- Add usage for canShareViaEmail and shareViaEmail
- Fix some formatting to be more consistent
- Fix pluginRef