### PR TITLE
Add hasPermission example to Push docs

### DIFF
--- a/src/plugins/push.ts
+++ b/src/plugins/push.ts
@@ -317,6 +317,13 @@ export class Push {
 
   /**
    * Check whether the push notification permission has been granted.
+   * 
+   * ```
+   * Push.hasPermission().then((data) => {
+     console.log(data.isEnabled);
+   });
+   * ```
+   * 
    * @return {Promise} Returns a Promise that resolves with an object with one property: isEnabled, a boolean that indicates if permission has been granted.
    */
   @Cordova()


### PR DESCRIPTION
This works a bit differently than [phonegap-plugin-push](https://github.com/phonegap/phonegap-plugin-push), so I would like to add a very simple example to the Push docs.