### PR TITLE
example added for Transfer plugin

### DIFF
--- a/src/plugins/filetransfer.ts
+++ b/src/plugins/filetransfer.ts
@@ -127,6 +127,27 @@ export interface FileTransferError {
  *
  * // Abort active transfer:
  * fileTransfer.abort();
+ *
+ * E.g
+ *
+ * upload(){
+ *   const fileTransfer = new Transfer();
+ *   var options: any;
+ *
+ *   options = {
+ *      fileKey: 'file',
+ *      fileName: 'name.jpg',
+ *      headers: {}
+ *      ..... 
+ *   }
+ *   fileTransfer.upload("<file path>", "<api endpoint>", options)
+ *    .then((data) => {
+ *      // success
+ *    }, (err) => {
+ *      // error
+ *    })
+ * }
+ *
  * ```
  *
  */


### PR DESCRIPTION
Hi,

Had a bit of difficulty on finding a complete example on using the [Transfer plugin](http://ionicframework.com/docs/v2/native/transfer/).  

I finally got it working and thought it would be nice to have a full example, so it might help someone in the future. 

I believe adding an example as a comment, will show that in the [documentation page](http://ionicframework.com/docs/v2/native/transfer/). If not please let me know where to do the changes :). 

cheers
Sam