### PR TITLE
Fix quotes on TouchID.isAvailable error comment

### DIFF
--- a/src/plugins/touchid.ts
+++ b/src/plugins/touchid.ts
@@ -28,7 +28,7 @@ import { Cordova, Plugin } from './plugin';
  * TouchID.isAvailable()
  *   .then(
  *     res => console.log('TouchID is available!'),
- *     err => console.error('TouchID isn't available', err)
+ *     err => console.error("TouchID isn't available", err)
  *   );
  *
  * TouchID.verifyFingerprint('Scan your fingerprint please')


### PR DESCRIPTION
You can see the documentation code coloring is off due to the quotation marks. I went with `"` instead of escaping.

<img width="1166" alt="screenshot 2016-07-30 14 07 09" src="https://cloud.githubusercontent.com/assets/134952/17272552/f0f0b9c2-565e-11e6-9e73-bdacd8a88a59.png">
