### PR TITLE
Change <Fabric API Key> to not break the doc formatter

### DIFF
--- a/src/plugins/twitter-connect.ts
+++ b/src/plugins/twitter-connect.ts
@@ -11,7 +11,7 @@ import { Plugin, Cordova } from './plugin';
   plugin: 'twitter-connect-plugin',
   pluginRef: 'TwitterConnect',
   repo: '',
-  install: 'ionic plugin add twitter-connect-plugin --variable FABRIC_KEY=<Fabric API Key>'
+  install: 'ionic plugin add twitter-connect-plugin --variable FABRIC_KEY=fabric_API_key'
 })
 export class TwitterConnect {
   /**


### PR DESCRIPTION
`<Fabric API Key>` seems to have broken http://ionicframework.com/docs/v2/native/twitter-connect/.

<img width="1189" alt="screenshot 2016-07-30 14 16 43" src="https://cloud.githubusercontent.com/assets/134952/17272603/4408877e-5660-11e6-8795-a57816b67a7d.png">
