### PR TITLE
fix(ng1): use $q promises instead of the native Promise

### DIFF
--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -88,13 +88,13 @@ function callCordovaPlugin(pluginObj: any, methodName: string, args: any[], opts
 }
 
 function getPromise(cb) {
-  if (window.Promise) {
-    return new Promise((resolve, reject) => {
-      cb(resolve, reject);
-    });
-  } else if (window.angular) {
+  if (window.angular) {
     let $q = window.angular.injector(['ng']).get('$q');
     return $q((resolve, reject) => {
+      cb(resolve, reject);
+    });
+  } else if (window.Promise) {
+    return new Promise((resolve, reject) => {
       cb(resolve, reject);
     });
   } else {


### PR DESCRIPTION
This is a partial fix for #348 and #367 (ES6 promise's are currently given priority over ng1's $q so a scope.$apply is required for all promise callbacks as $q is never actually used).

The other half involves using an observable to trigger a digest which should be possible by using the rxjs [scope scheduler](https://github.com/Reactive-Extensions/rx.angular.js/tree/master/docs#rxscopescheduler).