### PR TITLE
Added comment for iOS.

### DIFF
--- a/src/plugins/vibration.ts
+++ b/src/plugins/vibration.ts
@@ -10,6 +10,7 @@ import { Cordova, Plugin } from './plugin';
  *
  *
  * // Vibrate the device for a second
+ * // Duration is ignored on iOS. 
  * Vibration.vibrate(1000);
  *
  * // Vibrate 2 seconds


### PR DESCRIPTION
It doesn't matter what you send as the duration to vibrate() under iOS, it's always the same.