### PR TITLE
Exported Geolocation interfaces.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ export * from './plugins/devicemotion';
 export * from './plugins/deviceorientation';
 export * from './plugins/facebook';
 export * from './plugins/filetransfer';
+export * from './plugins/geolocation';
 export * from './plugins/googlemaps';
 export * from './plugins/httpd';
 export * from './plugins/ibeacon';
@@ -138,7 +139,6 @@ export {
   EmailComposer,
   File,
   Flashlight,
-  Geolocation,
   Globalization,
   GooglePlus,
   GoogleAnalytics,


### PR DESCRIPTION
I couldn't import `GeolocationOptions` and `Coordinates` from `ionic-angular`. Is there any reason not to export these interfaces?

Thank you :)