### PR TITLE
chore(): add plugin template and generator

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -5,6 +5,16 @@ This is a short guide on creating new plugin wrappers for Ionic Native.
 
 ## Creating Plugin Wrappers
 
+First, let's start by creating a new plugin wrapper from template.
+ 
+```
+// Call this command, and replace PluginName with the name of the plugin you wish to add
+// Make sure to capitalize the first letter, or use CamelCase if necessary.
+ 
+gulp plugin:create -n PluginName
+```
+
+
 Let's take a look at the existing plugin wrapper for Geolocation to see what goes into an Ionic Native plugin (comments have been removed for clarity):
 
 ```

--- a/TEMPLATE
+++ b/TEMPLATE
@@ -1,0 +1,50 @@
+/**
+ * This is a template for new plugin wrappers
+ *
+ * TODO:
+ * - Add/Change information below
+ * - Document usage (importing, executing main functionality)
+ * - Remove any imports that you are not using
+ * - Add this file to /src/index.ts (follow style of other plugins)
+ * - Remove all the comments included in this template, EXCEPT the @Plugin wrapper docs.
+ * - Remove this note
+ *
+ */
+import {Plugin, Cordova, CordovaProperty, CordovaInstance, InstanceProperty} from './plugin';
+import {Observable} from 'rxjs/Observable';
+
+/**
+ * @name PluginName
+ * @description
+ * This plugin does something
+ *
+ * @usage
+ * ```
+ * import {PluginName} from 'ionic-native';
+ *
+ * PluginName.functionName('Hello', 123)
+ *   .then((something: any) => doSomething(something))
+ *   .catch((error: any) => console.log(error));
+ *
+ * ```
+ */
+@Plugin({
+  plugin: '', // npm package name, example: cordova-plugin-camera
+  pluginRef: '', // the variable reference to call the plugin, example: navigator.geolocation
+  repo: '', // the github repository URL for the plugin
+  install: '' // OPTIONAL install command, in case the plugin requires variables
+})
+export class PluginName {
+
+  /**
+   * This function does something
+   * @param arg1 {string} Some param to configure something
+   * @param arg2 {number} Another param to configure something
+   * @return {Promise<any>} Returns a promise that resolves when something happens
+   */
+  @Cordova()
+  static functionName(arg1: string, arg2: number): Promise<any> {
+    return; // We add return; here to avoid any IDE / Compiler errors
+  }
+
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,8 @@ var minimist = require('minimist');
 var uglify = require('gulp-uglify');
 var rename = require("gulp-rename");
 var tslint = require('ionic-gulp-tslint');
+var decamelize = require('decamelize');
+var replace = require('gulp-replace');
 
 var flagConfig = {
   string: ['port', 'version', 'ngVersion', 'animations'],
@@ -26,3 +28,14 @@ gulp.task("minify:dist", function(){
 });
 
 gulp.task('lint', tslint);
+
+gulp.task('plugin:create', function(){
+  if(flags.n && flags.n !== ''){
+    return gulp.src('./TEMPLATE')
+      .pipe(replace('PluginName', flags.n))
+      .pipe(rename(decamelize(flags.n, '-') + '.ts'))
+      .pipe(gulp.dest('./src/plugins/'));
+  } else {
+    console.log("Usage is: gulp plugin:create -n PluginName");
+  }
+});

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
     "conventional-github-releaser": "^1.1.3",
     "cpr": "^1.0.0",
     "cz-conventional-changelog": "^1.1.6",
+    "decamelize": "^1.2.0",
     "dgeni": "^0.4.2",
     "dgeni-packages": "^0.10.18",
     "glob": "^6.0.4",
     "gulp": "^3.9.1",
     "gulp-rename": "^1.2.2",
+    "gulp-replace": "^0.5.4",
     "gulp-tslint": "^5.0.0",
     "gulp-uglify": "^1.5.4",
     "ionic-gulp-tslint": "^1.0.0",
@@ -42,7 +44,8 @@
     "build:js": "./node_modules/.bin/tsc",
     "build:bundle": "./node_modules/.bin/browserify dist/index.js > dist/ionic.native.js",
     "build:minify": "./node_modules/.bin/gulp minify:dist",
-    "changelog": "./node_modules/.bin/conventional-changelog -p angular -i CHANGELOG.md -s -r 0"
+    "changelog": "./node_modules/.bin/conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
+    "plugin:create": "gulp plugin:create"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Can now run the following command to generate a plugin wrapper from template + some instructions on how to use.

```
gulp plugin:create -n PluginName
// OR
npm run plugin:create -n PluginName
```