### PR TITLE
Add the reject function at the expected errorIndex position in the args array

### DIFF
--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -51,7 +51,13 @@ function setIndex(args: any[], opts: any = {}, resolve?: Function, reject?: Func
   } else if (typeof opts.successIndex !== 'undefined' || typeof opts.errorIndex !== 'undefined') {
     // If we've specified a success/error index
     args.splice(opts.successIndex, 0, resolve);
-    args.splice(opts.errorIndex, 0, reject);
+
+    // We don't want that the reject cb gets spliced into the position of an optional argument that has not been defined and thus causing non expected behaviour.
+    if (opts.errorIndex > args.length) {
+      args[opts.errorIndex] = reject; //insert the reject fn at the correct specific index
+    } else {
+      args.splice(opts.errorIndex, 0, reject); //otherwise just splice it into the array
+    }
   } else {
     // Otherwise, let's tack them on to the end of the argument list
     // which is 90% of cases


### PR DESCRIPTION
We don't want that the reject cb takes the position of an optional argument that has not been defined.
For example the Dialogs.alert method takes an optional 'buttonLabel' string. In case we do not set this value, and thus want to use the default value, the 'reject' callback get spliced into this position due the fact that the splice start index is bigger than the array length.

`Dialogs.alert('mytitle', 'mymessage', 'Okay')`
args will become: 
`["title",  resolve, "message", "My button text", reject]`

`Dialogs.alert("title", "message")`
args will become:
`["title", resolve, "message", reject]` 

The latter will invoke the **cordova-plugins-dialog** alert method with the wrong arguments
--> reject is on the position of the buttonLabel

**cordova-plugins-dialog** alert method signature
`alert: function(message, completeCallback, title, buttonLabel) {..}`