### PR TITLE
fix(ng1): remove the need to trigger digests on promise callbacks

### DIFF
--- a/src/ng1.ts
+++ b/src/ng1.ts
@@ -7,7 +7,9 @@ declare var window;
  */
 export function initAngular1(plugins) {
   if (window.angular) {
-    window.angular.module('ionic.native', []);
+    window.angular.module('ionic.native', []).run($q => {
+      window['IonicNative'].$q = $q;
+    });
 
     for (var name in plugins) {
       let serviceName = '$cordova' + name;

--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -3,7 +3,6 @@ import { Observable } from 'rxjs/Observable';
 
 declare var window;
 declare var Promise;
-declare var $q;
 
 
 /**
@@ -94,9 +93,8 @@ function callCordovaPlugin(pluginObj: any, methodName: string, args: any[], opts
 }
 
 function getPromise(cb) {
-  if (window.angular) {
-    let $q = window.angular.injector(['ng']).get('$q');
-    return $q((resolve, reject) => {
+  if (window['IonicNative'].$q) {
+    return window['IonicNative'].$q((resolve, reject) => {
       cb(resolve, reject);
     });
   } else if (window.Promise) {


### PR DESCRIPTION
Currently using `window.angular.injector(['ng']).get('$q');` will create a new angular injector instance which will create a new instance of $q and hence the $rootScope meaning the digests will trigger on a different cycle than the actual app. This is a hacky fix that gets `$q` via the run block and exposes it globally on the `IonicNative` global.