### PR TITLE
Fix the advanced table info

### DIFF
--- a/src/plugins/screen-orientation.ts
+++ b/src/plugins/screen-orientation.ts
@@ -23,7 +23,9 @@ declare var window;
  * ```
  *
  * @advanced
+ * 
  * Accepted orientation values:
+ * 
  * | Value                         | Description                                                                  |
  * |-------------------------------|------------------------------------------------------------------------------|
  * | portrait-primary              | The orientation is in the primary portrait mode.                             |
@@ -45,7 +47,7 @@ export class ScreenOrientation {
   /**
    * Lock the orientation to the passed value.
    * See below for accepted values
-   * @param {orientation} The orientation which should be locked. Accepted values see table above.
+   * @param {orientation} The orientation which should be locked. Accepted values see table below.
    */
   @Cordova({ sync: true })
   static lockOrientation(orientation: string): void { }


### PR DESCRIPTION
Well, seems like something was breaking the markdown table syntax.
Take a look at the screenshot below.
![adv-table](https://cloud.githubusercontent.com/assets/1139226/17985070/8cd1af96-6aea-11e6-952b-8b9117c2cbf2.PNG)
