### PR TITLE
feat(localNotifications): added register and has permission functions

### DIFF
--- a/src/plugins/localnotifications.ts
+++ b/src/plugins/localnotifications.ts
@@ -195,6 +195,20 @@ export class LocalNotifications {
   @Cordova()
   static getAllTriggered(): Promise<Array<Notification>> { return; }
 
+  /**
+   * Register permission to show notifications if not already granted.
+   * @returns {Promise} Returns a promise
+   */
+  @Cordova()
+  static registerPermission(): Promise<boolean> { return; }
+
+  /**
+   * Informs if the app has the permission to show notifications.
+   * @returns {Promise} Returns a promise
+   */
+  @Cordova()
+  static hasPermission(): Promise<boolean> { return; }
+
 
   /**
    * Sets a callback for a specific event


### PR DESCRIPTION
Added a couple of missing features from the cordova-plugin-local-notifications repo

https://github.com/katzer/cordova-plugin-local-notifications/wiki/04.-Scheduling#permission