### PR TITLE
fix(googlemaps): fixes parameter name for tile overlay

### DIFF
--- a/src/plugins/googlemaps.ts
+++ b/src/plugins/googlemaps.ts
@@ -872,7 +872,7 @@ export class GoogleMapsPolygon {
  * @private
  */
 export interface GoogleMapsTileOverlayOptions {
-  titleUrilFormat?: string;
+  tileUrlFormat?: string;
   visible?: boolean;
   zIndex?: number;
   tileSize?: number;


### PR DESCRIPTION
fixes #579