### PR TITLE
fix(googlemaps): CameraPosition target can now be GoogleMapsLatLng[]

### DIFF
--- a/src/plugins/googlemaps.ts
+++ b/src/plugins/googlemaps.ts
@@ -358,7 +358,7 @@ export interface AnimateCameraOptions {
  * @private
  */
 export interface CameraPosition {
-  target?: GoogleMapsLatLng | GoogleMapsLatLngBounds;
+  target?: GoogleMapsLatLng | GoogleMapsLatLngBounds | GoogleMapsLatLng[];
   zoom?: number;
   tilt?: number;
   bearing?: number;


### PR DESCRIPTION
add support GoogleMapsLatLng[] as target as [documentation](https://github.com/mapsplugin/cordova-plugin-googlemaps/wiki/CameraPosition) states 