### PR TITLE
BackgroundGeolocation configuration name change

### DIFF
--- a/src/plugins/background-geolocation.ts
+++ b/src/plugins/background-geolocation.ts
@@ -65,7 +65,7 @@ export interface Location {
   timestamp: number;
 }
 
-export interface Config {
+export interface BackgroundGeolocationConfig {
 
   /**
    * Desired accuracy in meters. Possible values [0, 10, 100, 1000]. The lower
@@ -239,7 +239,7 @@ export interface Config {
  *     // IMPORTANT: BackgroundGeolocation must be called within app.ts and or before Geolocation. Otherwise the platform will not ask you for background tracking permission. 
  * 
  *     // BackgroundGeolocation is highly configurable. See platform specific configuration options
- *     let config = {
+ *     let config:BackgroundGeolocationConfig = {
  *             desiredAccuracy: 10,
  *             stationaryRadius: 20,
  *             distanceFilter: 30,
@@ -329,7 +329,7 @@ export class BackgroundGeolocation {
    *
    * @param {Function} Success callback will be called when background location is determined.
    * @param {Function} Fail callback to be executed every time a geolocation error occurs.
-   * @param {Object} An object of type Config
+   * @param {Object} An object of type BackgroundGeolocationConfig
    *
    * @return Location object, which tries to mimic w3c Coordinates interface.
    * See http://dev.w3.org/geo/api/spec-source.html#coordinates_interface
@@ -338,7 +338,7 @@ export class BackgroundGeolocation {
   @Cordova({
     sync: true
   })
-  static configure(callback: Function, errorCallback: Function, options: Config): void { return; }
+  static configure(callback: Function, errorCallback: Function, options: BackgroundGeolocationConfig): void { return; }
 
   /**
    * Turn ON the background-geolocation system.
@@ -373,7 +373,7 @@ export class BackgroundGeolocation {
   @Cordova({
     callbackOrder: 'reverse'
   })
-  static setConfig(options: Config): Promise<any> { return; }
+  static setConfig(options: BackgroundGeolocationConfig): Promise<any> { return; }
 
   /**
    * Returns current stationaryLocation if available. null if not


### PR DESCRIPTION
Changed the name of 'Config' to 'BackgroundGeolocationConfig'  to avoid naming clashes in the future.