### PR TITLE
fix(googlemaps): typo in GoogleMapsTileOverlayOptions

### DIFF
--- a/src/plugins/googlemaps.ts
+++ b/src/plugins/googlemaps.ts
@@ -731,7 +731,7 @@ export class GoogleMapsPolygon {
  * @private
  */
 export interface GoogleMapsTileOverlayOptions {
-  titleUrlFormat?: string;
+  tileUrlFormat?: string;
   visible?: boolean;
   zIndex?: number;
   tileSize?: number;


### PR DESCRIPTION
related to my first PR (https://github.com/driftyco/ionic-native/pull/580) and this issue: https://github.com/driftyco/ionic-native/issues/579

The commit (https://github.com/driftyco/ionic-native/commit/f36b1c03cbaed2ddc71d4cbd02d55959d2267258) does not fix the issue.