### PR TITLE
Fix shareWithOptions method signature

### DIFF
--- a/src/plugins/socialsharing.ts
+++ b/src/plugins/socialsharing.ts
@@ -50,7 +50,7 @@ export class SocialSharing {
   @Cordova({
     platforms: ['iOS', 'Android']
   })
-  static shareWithOptions(options: { message?: string, subject?: string, file?: string|string[], url?: string, chooserTitle?: string }): Promise<any> { return; }
+  static shareWithOptions(options: { message?: string, subject?: string, files?: string|string[], url?: string, chooserTitle?: string }): Promise<any> { return; }
 
   /**
    * Checks if you can share via a specific app.


### PR DESCRIPTION
Fix shareWithOptions method signature, replacing 'options.file' property with 'options.files' to match social sharing plugin [method interface](https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin/blob/master/src/android/nl/xservices/plugins/SocialSharing.java#L209)