### PR TITLE
feat(googlemaps): support bounds in Geocoder

### DIFF
--- a/src/plugins/googlemaps.ts
+++ b/src/plugins/googlemaps.ts
@@ -900,6 +900,7 @@ export class GoogleMapsLatLng {
  */
 export interface GeocoderRequest {
   address?: string;
+  bounds?: GoogleMapsLatLng[];
   position?: { lat: number; lng: number };
 }
 /**


### PR DESCRIPTION
When using the `Geocoder.geocode` method, the area can be restricted to a rectangle using the bounds array. This array is optional and can contain two `LatLng` objects. The first `LatLng` specifies the lower left corner, the second `LatLng` specifies the upper right corner.

See:
[Implementation in the plugin](https://github.com/mapsplugin/cordova-plugin-googlemaps/blob/30a28dfee236bbdaa95e17b752f9c40116069b44/src/android/plugin/google/maps/MyGeocoder.java#L64)
[Android developer docs for the used method](https://developer.android.com/reference/android/location/Geocoder.html#getFromLocationName(java.lang.String, int, double, double, double, double))