### PR TITLE
fix(push): Add support for passing notification id into finish

### DIFF
--- a/src/plugins/push.ts
+++ b/src/plugins/push.ts
@@ -134,8 +134,9 @@ export interface PushNotification {
    * successHandler gets called when background push processing is successfully completed.
    * @param successHandler
    * @param errorHandler
+   * @param id
    */
-  finish(successHandler: () => any, errorHandler: () => any): void;
+  finish(successHandler: () => any, errorHandler: () => any, id?: string): void;
 }
 
 export interface IOSPushOptions {


### PR DESCRIPTION
This is included in the push plugin typings but is missing from Ionic Native: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/phonegap-plugin-push/phonegap-plugin-push.d.ts