### PR TITLE
fix(PowerManagement): repo url

### DIFF
--- a/src/plugins/power-management.ts
+++ b/src/plugins/power-management.ts
@@ -17,8 +17,8 @@ import { Plugin, Cordova } from './plugin';
  */
 @Plugin({
   plugin: 'cordova-plugin-powermanagement-orig',
-  pluginRef: 'https://github.com/Viras-/cordova-plugin-powermanagement',
-  repo: 'powerManagement'
+  pluginRef: 'powerManagement',
+  repo: 'https://github.com/Viras-/cordova-plugin-powermanagement'
 })
 export class PowerManagement {
   /**


### PR DESCRIPTION
Fixes the link that is generated in the docs here
http://ionicframework.com/docs/v2/native/powermanagement/