### PR TITLE
[PayPal] Fixed bug with currency code not found

### DIFF
--- a/src/plugins/pay-pal.ts
+++ b/src/plugins/pay-pal.ts
@@ -101,13 +101,13 @@ export class PayPalPayment {
    * Convenience constructor.
    * Returns a PayPalPayment with the specified amount, currency code, and short description.
    * @param {String} amount: The amount of the payment.
-   * @param {String} currencyCode: The ISO 4217 currency for the payment.
+   * @param {String} currency: The ISO 4217 currency for the payment.
    * @param {String} shortDescription: A short description of the payment.
    * @param {String} intent: "Sale" for an immediate payment.
    */
-  constructor(amount: string, currencyCode: string, shortDescription: string, intent: string) {
+  constructor(amount: string, currency: string, shortDescription: string, intent: string) {
     this.amount = amount;
-    this.currencyCode = currencyCode;
+    this.currency = currency;
     this.shortDescription = shortDescription;
     this.intent = intent;
   }
@@ -119,7 +119,7 @@ export class PayPalPayment {
   /**
    * The ISO 4217 currency for the payment.
    */
-  currencyCode: string;
+  currency: string;
   /**
    * A short description of the payment.
    */


### PR DESCRIPTION
Hey guys,

I'm getting this error while using the ionic-native PayPal plugin.

    PayPal SDK: PayPalPayment not processable: Currency code is required.

**I'm using this code:**

	PayPal.init({
	  "PayPalEnvironmentProduction": "YOUR_PRODUCTION_CLIENT_ID",
	  "PayPalEnvironmentSandbox": "YOUR_SANDBOX_CLIENT_ID"
	}).then(() => {
	  let payment = new PayPalPayment('1.23', 'EUR', 'Charge money', 'intent');
	  PayPal.renderSinglePaymentUI(payment).then((s) => {
	    console.log('SUCCESS RENDER INIT', s);
	  }, (e) => {
	    console.log('ERROR RENDER INIT', e);
	  });
	}, (e) => {
	  console.log('ERROR PAYPAL INIT', e);
	});

**Explanation of this issue:**
The PayPal-Cordova-Plugin uses the _currency_ from the array instead _currencyCode_ so that this can never work. See https://github.com/paypal/PayPal-Cordova-Plugin/blob/master/src/ios/PayPalMobileCordovaPlugin.m#L97

The official JS file says the same. See https://github.com/paypal/PayPal-Cordova-Plugin/blob/master/www/paypal-mobile-js-helper.js#L49

After this change it works fine 👍 