### PR TITLE
Fixed problems with selection of PayPal environment

### DIFF
--- a/src/plugins/pay-pal.ts
+++ b/src/plugins/pay-pal.ts
@@ -32,22 +32,32 @@ import { Plugin, Cordova } from './plugin';
 })
 export class PayPal {
   /**
+   * Retrieve the version of the PayPal iOS SDK library. Useful when contacting support.
+   */
+  @Cordova()
+  static version(): Promise<string> {return; }
+
+  /**
    * You must preconnect to PayPal to prepare the device for processing payments.
    * This improves the user experience, by making the presentation of the
    * UI faster. The preconnect is valid for a limited time, so
    * the recommended time to preconnect is on page load.
    *
-   * @param {String} environment available options are "PayPalEnvironmentNoNetwork", "PayPalEnvironmentProduction" and "PayPalEnvironmentSandbox"
-   * @param {PayPalConfiguration} configuration For Future Payments merchantName, merchantPrivacyPolicyURL and merchantUserAgreementURL must be set be set
+   * @param {PayPalEnvironment} clientIdsForEnvironments: set of client ids for environments
    */
   @Cordova()
-  static init(environment: PayPalEnvironment, configuration?: PayPalConfiguration): Promise<any> {return; }
+  static init(clientIdsForEnvironments: PayPalEnvironment): Promise<any> {return; }
 
   /**
-   * Retreive the version of PayPal iOS SDK Library.
-   */
+   * You must preconnect to PayPal to prepare the device for processing payments.
+   * This improves the user experience, by making the presentation of the UI faster.
+   * The preconnect is valid for a limited time, so the recommended time to preconnect is on page load.
+   *
+   * @param {String} environment: available options are "PayPalEnvironmentNoNetwork", "PayPalEnvironmentProduction" and "PayPalEnvironmentSandbox"
+   * @param {PayPalConfiguration} configuration: PayPalConfiguration object, for Future Payments merchantName, merchantPrivacyPolicyURL and merchantUserAgreementURL must be set be set
+   **/
   @Cordova()
-  static version(): Promise<string> {return; }
+  static prepareToRender(environment: string, configuration: PayPalConfiguration): Promise<any> {return; }
 
   /**
    * Start PayPal UI to collect payment from the user.
@@ -85,7 +95,6 @@ export class PayPal {
    **/
   @Cordova()
   static renderProfileSharingUI(scopes: string[]): Promise<any> {return; }
-
 }
 
 export interface PayPalEnvironment {

--- a/src/plugins/pay-pal.ts
+++ b/src/plugins/pay-pal.ts
@@ -6,15 +6,47 @@ import { Plugin, Cordova } from './plugin';
  *
  * @usage
  * ```
- * import {PayPal} from 'ionic-native';
+ * import {PayPal, PayPalPayment, PayPalConfiguration} from "ionic-native";
  *
  * PayPal.init({
- *      "PayPalEnvironmentProduction": "YOUR_PRODUCTION_CLIENT_ID",
-       "PayPalEnvironmentSandbox": "YOUR_SANDBOX_CLIENT_ID"
-       })
- *   .then(onSuccess)
- *   .catch(onError);
+ *   "PayPalEnvironmentProduction": "YOUR_PRODUCTION_CLIENT_ID",
+ *   "PayPalEnvironmentSandbox": "YOUR_SANDBOX_CLIENT_ID"
+ * }).then(() => {
+ *   // Environments: PayPalEnvironmentNoNetwork, PayPalEnvironmentSandbox, PayPalEnvironmentProduction
+ *   PayPal.prepareToRender('PayPalEnvironmentSandbox', new PayPalConfiguration({
+ *     // Only needed if you get an "Internal Service Error" after PayPal login!
+ *     //payPalShippingAddressOption: 2 // PayPalShippingAddressOptionPayPal
+ *   })).then(() => {
+ *     let payment = new PayPalPayment('3.33', 'USD', 'Description', 'sale');
+ *     PayPal.renderSinglePaymentUI(payment).then(() => {
+ *       // Successfully paid
  *
+ *       // Example sandbox response
+ *       //
+ *       // {
+ *       //   "client": {
+ *       //     "environment": "sandbox",
+ *       //     "product_name": "PayPal iOS SDK",
+ *       //     "paypal_sdk_version": "2.16.0",
+ *       //     "platform": "iOS"
+ *       //   },
+ *       //   "response_type": "payment",
+ *       //   "response": {
+ *       //     "id": "PAY-1AB23456CD789012EF34GHIJ",
+ *       //     "state": "approved",
+ *       //     "create_time": "2016-10-03T13:33:33Z",
+ *       //     "intent": "sale"
+ *       //   }
+ *       // }
+ *     }, () => {
+ *       // Error or render dialog closed without being successful
+ *     });
+ *   }, () => {
+ *     // Error in configuration
+ *   });
+ * }, () => {
+ *   // Error in initialization, maybe PayPal isn't supported or something else
+ * });
  * ```
  * @interfaces
  * PayPalEnvironment


### PR DESCRIPTION
After I fixed the other #653 problem I find out that I'm unable to leave the "NoNetwork" mock environment.
So I searched for a solution and I found out that the PayPal scripts are not up to date with the cordova plugin repository.

With this update we are able to use PayPal via ionic-native in production and sandbox environments. So we can work with IPN's and everything and test as we like.

**Example pay flow...**

	import {PayPal, PayPalPayment, PayPalConfiguration} from "ionic-native";

_[...]_

	PayPal.init({
		"PayPalEnvironmentProduction": "YOUR_PRODUCTION_CLIENT_ID",
		"PayPalEnvironmentSandbox": "YOUR_SANDBOX_CLIENT_ID"
	}).then(() => {
		/** Environments: PayPalEnvironmentNoNetwork, PayPalEnvironmentSandbox, PayPalEnvironmentProduction */
		PayPal.prepareToRender('PayPalEnvironmentSandbox', new PayPalConfiguration({
			/** Only needed if you get an "Internal Service Error" after PayPal login! */
			//payPalShippingAddressOption: 2 // PayPalShippingAddressOptionPayPal
		})).then(() => {
			let payment = new PayPalPayment('3.33', 'USD', 'Description', 'intent');
			PayPal.renderSinglePaymentUI(payment).then(() => {
				// Successfully paid

				/**
				 * Example sandbox response
				 *
				 * {
				 *   "client": {
				 *     "environment": "sandbox",
				 *     "product_name": "PayPal iOS SDK",
				 *     "paypal_sdk_version": "2.16.0",
				 *     "platform": "iOS"
				 *   },
				 *   "response_type": "payment",
				 *   "response": {
				 *     "id": "PAY-1AB23456CD789012EF34GHIJ",
				 *     "state": "approved",
				 *     "create_time": "2016-10-03T13:33:33Z",
				 *     "intent": "sale"
				 *   }
				 * }
				 */
			}, () => {
				// Error or render dialog closed without being successful
			});
		}, () => {
			// Error in configuration
		});
	}, () => {
		// Error in initialization, maybe PayPal isn't supported or something else
	});

I had a error with the login to PayPal after switching from the Mock-NoNetwork environment to the sandbox environment. "Internal Service error". After play around a bit with the PayPal Sample iOS App I found out that I must set the optional payPalShippingAddressOption to PayPalShippingAddressOptionPayPal. I added this in the example above so that you can do the same if you have the same issue. 👍 