### PR TITLE
fix(googlemaps): Expose 'type' property in GoogleMapsLatLngBounds #693

### DIFF
--- a/src/plugins/googlemaps.ts
+++ b/src/plugins/googlemaps.ts
@@ -885,6 +885,7 @@ export class GoogleMapsLatLngBounds {
 
   @InstanceProperty get northeast(): GoogleMapsLatLng { return; }
   @InstanceProperty get southwest(): GoogleMapsLatLng { return; }
+  @InstanceProperty get type(): string { return; }
 
   constructor(southwestOrArrayOfLatLng: GoogleMapsLatLng | GoogleMapsLatLng[], northeast?: GoogleMapsLatLng) {
     let args = !!northeast ? [southwestOrArrayOfLatLng, northeast] : southwestOrArrayOfLatLng;


### PR DESCRIPTION
Adds the type property to GoogleMapsLatLngBounds

**Fixes:** #693 