### PR TITLE
fix(datepicker): fix DatePicker allowOldDates option

### DIFF
--- a/src/plugins/datepicker.ts
+++ b/src/plugins/datepicker.ts
@@ -59,7 +59,7 @@ export interface DatePickerOptions {
   /**
    * Shows or hide dates earlier then selected date.
    */
-  allowOldDate?: boolean;
+  allowOldDates?: boolean;
   /**
    * Shows or hide dates after selected date.
    */


### PR DESCRIPTION
Changed `allowOldDate` property to `allowOldDates`

See documentation: https://github.com/VitaliiBlagodir/cordova-plugin-datepicker#allowolddates---ios