### PR TITLE
Fix typo in inappbrowser.ts

### DIFF
--- a/src/plugins/inappbrowser.ts
+++ b/src/plugins/inappbrowser.ts
@@ -39,7 +39,7 @@ export interface InAppBrowserEvent extends Event {
 export class InAppBrowser {
 
   static open(url: string, target?: string, options?: string): void {
-    console.warn('Native: Your current usage of the InAppBrowser plugin is depreciated as of ionic-native@1.3.8. Please check the Ionic Native docs for the latest usage details.');
+    console.warn('Native: Your current usage of the InAppBrowser plugin is deprecated as of ionic-native@1.3.8. Please check the Ionic Native docs for the latest usage details.');
   }
 
   private _objectInstance: any;


### PR DESCRIPTION
It's [deprecated](https://www.google.com/search?q=deprecated) not [depreciated](https://www.google.com/search?q=depreciated).