### PR TITLE
Fixing issue #789 - File.writeFile was broken.

### DIFF
--- a/src/plugins/file.ts
+++ b/src/plugins/file.ts
@@ -678,8 +678,8 @@ export class File {
     }
 
     let getFileOpts: Flags = {
-      create: true,
-      exclusive: options.replace
+      create: !options.append,
+      exclusive: !options.replace
     };
 
     return File.resolveDirectoryUrl(path)


### PR DESCRIPTION
Prior to this patch, `File.writeFile` has the `replace` and `append`
options flipped; setting `replace: true` would block the file from being
replaced, and setting `append: true` would always create a new file and
never append.