### PR TITLE
docs(media-capture): fix documentation mixup

### DIFF
--- a/src/plugins/media-capture.ts
+++ b/src/plugins/media-capture.ts
@@ -29,7 +29,7 @@ declare var navigator: any;
 })
 export class MediaCapture {
   /**
-   * The audio recording formats supported by the device.
+   * The recording image sizes and formats supported by the device.
    * @returns {ConfigurationData[]}
    */
   @CordovaProperty
@@ -38,7 +38,7 @@ export class MediaCapture {
   }
 
   /**
-   * The recording image sizes and formats supported by the device.
+   * The audio recording formats supported by the device.
    * @returns {ConfigurationData[]}
    */
   @CordovaProperty


### PR DESCRIPTION
Comment for `supportedImageModes()` meant for `supportedAudioModes()` and vice-versa.