### PR TITLE
Plugin reference fix

### DIFF
--- a/src/plugins/market.ts
+++ b/src/plugins/market.ts
@@ -15,7 +15,7 @@ import { Plugin, Cordova } from './plugin';
 @Plugin({
   pluginName: 'Market',
   plugin: 'cordova-plugin-market',
-  pluginRef: 'plugins.market',
+  pluginRef: 'cordova.plugins.market',
   repo: 'https://github.com/xmartlabs/cordova-plugin-market'
 })
 export class Market {


### PR DESCRIPTION
The plugin reference is available as part of the global `cordova` object and not the global `plugins` object. This caused the plugin to `Plugin not installed warning` even though the plugin is installed and works when using through `cordova.plugins.market.open(appId);`