### PR TITLE
Revert plugin and update repo to match

### DIFF
--- a/src/plugins/camera-preview.ts
+++ b/src/plugins/camera-preview.ts
@@ -19,7 +19,7 @@ export interface CameraPreviewSize {
  * @description
  * Showing camera preview in HTML
  *
- * For more info, please see the [Cordova Camera Preview Plugin Docs](https://github.com/westonganger/cordova-plugin-camera-preview).
+ * For more info, please see the [Cordova Camera Preview Plugin Docs](https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview).
  *
  * @usage
  * ```
@@ -72,7 +72,7 @@ export interface CameraPreviewSize {
   pluginName: 'CameraPreview',
   plugin: 'cordova-plugin-camera-preview',
   pluginRef: 'cordova.plugins.camerapreview',
-  repo: 'https://github.com/westonganger/cordova-plugin-camera-preview',
+  repo: 'https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview',
   platforms: ['Android', 'iOS']
 })
 export class CameraPreview {

--- a/src/plugins/camera-preview.ts
+++ b/src/plugins/camera-preview.ts
@@ -38,7 +38,7 @@ export interface CameraPreviewSize {
  * CameraPreview.startCamera(
  *   cameraRect, // position and size of preview
  *   'front', // default camera
- *   true, // tape to take picture
+ *   true, // tap to take picture
  *   false, // disable drag
  *   true // send the preview to the back of the screen so we can add overlaying elements
  * );

--- a/src/plugins/camera-preview.ts
+++ b/src/plugins/camera-preview.ts
@@ -70,9 +70,9 @@ export interface CameraPreviewSize {
  */
 @Plugin({
   pluginName: 'CameraPreview',
-  plugin: 'https://github.com/westonganger/cordova-plugin-camera-preview',
+  plugin: 'cordova-plugin-camera-preview',
   pluginRef: 'cordova.plugins.camerapreview',
-  repo: 'https://github.com/westonganger/cordova-plugin-camera-preview',
+  repo: 'https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview',
   platforms: ['Android', 'iOS']
 })
 export class CameraPreview {

--- a/src/plugins/camera-preview.ts
+++ b/src/plugins/camera-preview.ts
@@ -70,9 +70,9 @@ export interface CameraPreviewSize {
  */
 @Plugin({
   pluginName: 'CameraPreview',
-  plugin: 'cordova-plugin-camera-preview',
+  plugin: 'https://github.com/westonganger/cordova-plugin-camera-preview',
   pluginRef: 'cordova.plugins.camerapreview',
-  repo: 'https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview',
+  repo: 'https://github.com/westonganger/cordova-plugin-camera-preview',
   platforms: ['Android', 'iOS']
 })
 export class CameraPreview {


### PR DESCRIPTION
The newer repo reference in the README is incomplete, and does not function. This PR reverts to the older operable plugin, and assigns the appropriate repo to match.