### PR TITLE
Update sqlite.ts

### DIFF
--- a/src/plugins/sqlite.ts
+++ b/src/plugins/sqlite.ts
@@ -21,7 +21,7 @@ declare var sqlitePlugin;
  * })
  *   .then((db: SQLite) => {
  *
- *     db.executeSQL('create table danceMoves(name VARCHAR(32))').then(() => {}).catch(() => {});
+ *     db.executeSql('create table danceMoves(name VARCHAR(32))').then(() => {}).catch(() => {});
  *
  *   })
  *   .catch(error => console.error('Error openening database', error);


### PR DESCRIPTION
`db.executeSql()` was documented as `db.executeSQL()` that caused error:

    main.js:13 Error openening database TypeError: t.executeSQL is not a function
        at file:///android_asset/www/build/main.js:13:11718
        at t.invoke (file:///android_asset/www/build/polyfills.js:3:13422)
        at Object.onInvoke (file:///android_asset/www/build/main.js:3:3341)
        at t.invoke (file:///android_asset/www/build/polyfills.js:3:13373)
        at e.run (file:///android_asset/www/build/polyfills.js:3:10809)
        at file:///android_asset/www/build/polyfills.js:3:8911
        at t.invokeTask (file:///android_asset/www/build/polyfills.js:3:14051)
        at Object.onInvokeTask (file:///android_asset/www/build/main.js:3:3241)
        at t.invokeTask (file:///android_asset/www/build/polyfills.js:3:13987)
        at e.runTask (file:///android_asset/www/build/polyfills.js:3:11411)

The issue is fixed in this commit