### PR TITLE
Parameter (size) is optional

### DIFF
--- a/src/plugins/camera-preview.ts
+++ b/src/plugins/camera-preview.ts
@@ -117,7 +117,7 @@ export class CameraPreview {
   @Cordova({
     sync: true
   })
-  static takePicture(size: CameraPreviewSize): void { }
+  static takePicture(size?: CameraPreviewSize): void { }
 
   /**
    * Register a callback function that receives the original picture and the image captured from the preview box.


### PR DESCRIPTION
Just added the '?' to the parameter (size) in the static takePicture(size?: CameraPreviewSize): void { } because the size is a optional parameter