### PR TITLE
fix(diagnostic): add permissionStatus types

### DIFF
--- a/src/plugins/diagnostic.ts
+++ b/src/plugins/diagnostic.ts
@@ -66,12 +66,12 @@ export class Diagnostic {
 
   @CordovaProperty
   static permissionStatus: {
-    GRANTED;
-    DENIED;
-    NOT_REQUESTED;
-    DENIED_ALWAYS;
-    RESTRICTED;
-    GRANTED_WHEN_IN_USE;
+    GRANTED: string;
+    DENIED: string;
+    NOT_REQUESTED: string;
+    DENIED_ALWAYS: string;
+    RESTRICTED: string;
+    GRANTED_WHEN_IN_USE: string;
   };
 
   static locationAuthorizationMode = {


### PR DESCRIPTION
The latest release of Ionic Native started giving me errors because I'm using the ts `noImplicitAny` option.

This adds the missing types to the diagnostic plugin.