### PR TITLE
add altitudeAccuracy into BackgroundGeolocationResponse

### DIFF
--- a/src/plugins/background-geolocation.ts
+++ b/src/plugins/background-geolocation.ts
@@ -48,6 +48,11 @@ export interface BackgroundGeolocationResponse {
    * altitude if available, in meters above the WGS 84 reference ellipsoid.
    */
   altitude: number;
+  
+  /**
+    * accuracy of the altitude if available.
+    */
+  altitudeAccuracy: number;
 
   /**
    * bearing, in degrees.


### PR DESCRIPTION
I figured out that altitudeAccuracy is missing based on my result in ios sim