### PR TITLE
style: fix whitespace lint issue

### DIFF
--- a/src/plugins/background-geolocation.ts
+++ b/src/plugins/background-geolocation.ts
@@ -48,7 +48,7 @@ export interface BackgroundGeolocationResponse {
    * altitude if available, in meters above the WGS 84 reference ellipsoid.
    */
   altitude: number;
-  
+
   /**
     * accuracy of the altitude if available.
     */


### PR DESCRIPTION
Fix a whitespace lint issue that makes `npm run lint` fail