### PR TITLE
fix(onesignal): Made OSNotification::app_id optional

### DIFF
--- a/src/plugins/onesignal.ts
+++ b/src/plugins/onesignal.ts
@@ -26,7 +26,7 @@ export interface OSNotification {
    * **ANDROID** - Notification is a summary notification for a group this will contain all notification payloads it was created from.
    */
   groupedNotifications?: OSNotificationPayload[];
-  app_id: string;
+  app_id?: string;
   contents: any;
   headings?: any;
   isIos?: boolean;


### PR DESCRIPTION
OSNotification::app_id is not required when sending a selfNotification.