### PR TITLE
chore(): replace try/catch with better approach

### DIFF
--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -124,15 +124,16 @@ function callCordovaPlugin(pluginObj: any, methodName: string, args: any[], opts
   }
 
   // TODO: Illegal invocation needs window context
-  let value;
-  try {
-    value = get(window, pluginObj.pluginRef)[methodName].apply(pluginInstance, args);
-  } catch (e) {
-    value = {
-      error: 'cordova_not_available'
+  const ref = get(window, pluginObj.pluginRef);
+
+  if (ref && ref.hasOwnProperty(methodName)) {
+    return get(window, pluginObj.pluginRef)[methodName].apply(pluginInstance, args);
+  } else {
+    pluginWarn(pluginObj, methodName);
+    return {
+      error: 'plugin_not_installed'
     };
   }
-  return value;
 }
 
 /**

--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -108,7 +108,7 @@ function callCordovaPlugin(pluginObj: any, methodName: string, args: any[], opts
 
   let pluginInstance = getPlugin(pluginObj.pluginRef);
 
-  if (!pluginInstance) {
+  if (!pluginInstance || !pluginInstance.hasOwnProperty(methodName)) {
     // Do this check in here in the case that the Web API for this plugin is available (for example, Geolocation).
     if (!window.cordova) {
       cordovaWarn(pluginObj.pluginName, methodName);
@@ -123,17 +123,7 @@ function callCordovaPlugin(pluginObj: any, methodName: string, args: any[], opts
     };
   }
 
-  // TODO: Illegal invocation needs window context
-  const ref = get(window, pluginObj.pluginRef);
-
-  if (ref && ref.hasOwnProperty(methodName)) {
-    return get(window, pluginObj.pluginRef)[methodName].apply(pluginInstance, args);
-  } else {
-    pluginWarn(pluginObj, methodName);
-    return {
-      error: 'plugin_not_installed'
-    };
-  }
+  return pluginInstance[methodName].apply(pluginInstance, args);
 }
 
 /**


### PR DESCRIPTION
I previously pushed a commit to wrap the `callCordovaPlugin` with a try/catch block. This approach wasn't ideal because in some cases the plugins have issues (uncaught exceptions) and the try/catch is getting rid of the necessary console logs for debugging.

https://github.com/driftyco/ionic-native/commit/54d1a9891beca23d229ff3b064110f3de6c86da2

This commit fixes that by only handling cases where the `pluginRef` exists  but the method doesn't exist. For example, the screen orientation plugin uses `window.screen` variable that exists on all devices, but only has the orientation property on mobile devices.