### PR TITLE
docs(google-maps) Make it clear that the map element needs a height

### DIFF
--- a/src/plugins/googlemap.ts
+++ b/src/plugins/googlemap.ts
@@ -60,8 +60,9 @@ export const GoogleMapsAnimation = {
  *
  * loadMap() {
  *  // make sure to create following structure in your view.html file
+ *  // and add a height (for example 100%) to it, else the map won't be visible
  *  // <ion-content>
- *  //  <div #map id="map"></div>
+ *  //  <div #map id="map" style="height:100%;"></div>
  *  // </ion-content>
  *
  *  // create a new map by passing HTMLElement


### PR DESCRIPTION
I added a change that makes it clear that the map element needs a height to be visible.

I tried to follow the docs but It didn't work, after that I thought my API keys were invalid, at the end it turned out the map wasn't visible at all.