### PR TITLE
Fix exception in CordovaProperty

### DIFF
--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -407,8 +407,8 @@ export function CordovaInstance(opts: any = {}) {
  * Before calling the original method, ensure Cordova and the plugin are installed.
  */
 export function CordovaProperty(target: any, key: string) {
-  const pluginInstance = getPlugin(target.pluginRef);
   const exists = () => {
+    let pluginInstance = getPlugin(target.pluginRef);
     if (!pluginInstance || pluginInstance[key] === 'undefined') {
       pluginWarn(target, key);
       return false;
@@ -419,14 +419,14 @@ export function CordovaProperty(target: any, key: string) {
   Object.defineProperty(target, key, {
     get: () => {
       if (exists()) {
-        return pluginInstance[key];
+        return getPlugin(target.pluginRef)[key];
       } else {
         return null;
       }
     },
     set: (value) => {
       if (exists()) {
-        pluginInstance[key] = value;
+        getPlugin(target.pluginRef)[key] = value;
       }
     }
   });


### PR DESCRIPTION
This reverts part of commit 67adb23, which moved the call to getPlugin()
from within CordovaProperty() to a point where it was called too early.

When the CordovaProperty decorator is called on a property, the class
containing that call has not yet had its Plugin decorator called. Only
when the latter happens does pluginRef get set. Thus, attempting to
access pluginRef within CordovaProperty at the time of the call will
give undefined, and attemping to call getPlugin with an undefined value
will throw an exception:

    Runtime Error
    Cannot read property 'split' of undefined

    TypeError: Cannot read property 'split' of undefined
        at get
        at getPlugin
        at CordovaProperty
        at __decorate
        ...

The above message can be seen in the browser after running the 'ionic
serve' command.

This commit moves the getPlugin call back to the getters and setters
established by CordovaProperty, which are only called *after* the Plugin
decorator has finished executing.

closes #954