### PR TITLE
Updating docs (seconds -> milliseconds) and adding options for ANDROID_ACTIVITY_PROVIDER provider

### DIFF
--- a/src/plugins/background-fetch.ts
+++ b/src/plugins/background-fetch.ts
@@ -1,0 +1,107 @@
+import {Cordova, Plugin} from './plugin';
+
+declare var window;
+
+
+export interface BackgroundFetchConfig {
+
+  /**
+   * Set true to cease background-fetch from operating after user "closes" the app. Defaults to true.
+   */
+  stopOnTerminate?: boolean;
+}
+
+
+/**
+ * @name BackgroundFetch
+ * @description
+ * iOS Background Fetch Implementation. See: https://developer.apple.com/reference/uikit/uiapplication#1657399
+ * iOS Background Fetch is basically an API which wakes up your app about every 15 minutes (during the user's prime-time hours) and provides your app exactly 30s of background running-time. This plugin will execute your provided callbackFn whenever a background-fetch event occurs. There is no way to increase the rate which a fetch-event occurs and this plugin sets the rate to the most frequent possible value of UIApplicationBackgroundFetchIntervalMinimum -- iOS determines the rate automatically based upon device usage and time-of-day (ie: fetch-rate is about ~15min during prime-time hours; less frequently when the user is presumed to be sleeping, at 3am for example).
+ * For more detail, please see https://github.com/transistorsoft/cordova-plugin-background-fetch
+ *
+ * @usage
+ *
+ * ```typescript
+ * import { BackgroundFetch } from 'ionic-native';
+ *
+ *
+ * // When device is ready :
+ * platform.ready().then(() => {
+ *
+ *   let config = {
+ *     stopOnTerminate: false, // Set true to cease background-fetch from operating after user "closes" the app. Defaults to true.
+ *   };
+ *
+ *   BackgroundFetch.configure(() => {
+       console.log('[js] BackgroundFetch initiated');
+
+       // perform some ajax request to server here
+
+       You MUST called #finish so that native-side can signal completion of the background-thread to the os.
+       BackgroundFetch.finish();
+
+ *   }, (error) => {
+ *     console.log('- BackgroundFetch failed', error);
+ *   }, config);
+ *
+ * });
+ *
+ * // Start the background-fetch API. Your callbackFn provided to #configure will be executed each time a background-fetch event occurs. NOTE the #configure method automatically calls #start. You do not have to call this method after you #configure the plugin
+ * BackgroundFetch.start();
+ *
+ * // Stop the background-fetch API from firing fetch events. Your callbackFn provided to #configure will no longer be executed.
+ * BackgroundFetch.stop();
+ *
+ * ```
+ * @interfaces
+ * BackgroundFetchConfig
+ *
+ */
+@Plugin({
+  pluginName: 'BackgroundFetch',
+  plugin: 'cordova-plugin-background-fetch',
+  pluginRef: 'BackgroundFetch',
+  repo: 'https://github.com/transistorsoft/cordova-plugin-background-fetch',
+  platforms: ['iOS']
+})
+export class BackgroundFetch {
+
+
+  /**
+   * Configures the plugin's fetch callbackFn
+   *
+   * @param {Function} callbackFn This callback will fire each time an iOS background-fetch event occurs (typically every 15 min).
+   * @param {Function} errorCallback The failureFn will be called if the device doesn't support background-fetch.
+   * @param {BackgroundFetchConfig} config Configuration for plugin
+   * @return Location object, which tries to mimic w3c Coordinates interface.
+   * See http://dev.w3.org/geo/api/spec-source.html#coordinates_interface
+   * Callback to be executed every time a geolocation is recorded in the background.
+   */
+  @Cordova({
+    sync: true
+  })
+  static configure(callbackFn: Function, errorCallback: Function, config: BackgroundFetchConfig): any { return; }
+
+
+
+  /**
+   * Start the background-fetch API.
+   * Your callbackFn provided to #configure will be executed each time a background-fetch event occurs. NOTE the #configure method automatically calls #start. You do not have to call this method after you #configure the plugin
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  static start(): Promise<any> { return; }
+
+  /**
+   * Stop the background-fetch API from firing fetch events. Your callbackFn provided to #configure will no longer be executed.
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  static stop(): Promise<any> { return; }
+
+  /**
+   * You MUST call this method in your fetch callbackFn provided to #configure in order to signal to iOS that your fetch action is complete. iOS provides only 30s of background-time for a fetch-event -- if you exceed this 30s, iOS will kill your app.
+   */
+  @Cordova()
+  static finish() { }
+}

--- a/src/plugins/background-geolocation.ts
+++ b/src/plugins/background-geolocation.ts
@@ -126,10 +126,14 @@ export interface BackgroundGeolocationConfig {
 
   /**
    * ANDROID, WP8 ONLY
-   * The minimum time interval between location updates in seconds.
+   * When using BackgroundGeolocation.LocationProvider.ANDROID_DISTANCE_FILTER_PROVIDER:
+   * The minimum time interval between location updates in milliseconds.
    * @see Android docs (http://developer.android.com/reference/android/location/LocationManager.html#requestLocationUpdates(long,%20float,%20android.location.Criteria,%20android.app.PendingIntent))
    * and the MS doc (http://msdn.microsoft.com/en-us/library/windows/apps/windows.devices.geolocation.geolocator.reportinterval)
    * for more information
+   * When using BackgroundGeolocation.LocationProvider.ANDROID_ACTIVITY_PROVIDER:
+   * Rate in milliseconds at which your app prefers to receive location updates.
+   * @see Android docs (https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest.html#getInterval())
    */
   interval?: number;
 
@@ -225,6 +229,28 @@ export interface BackgroundGeolocationConfig {
    * Defaults to 10000 
    */
   maxLocations?: number;
+
+  /**
+   * ANDROID ONLY with BackgroundGeolocation.LocationProvider.ANDROID_ACTIVITY_PROVIDER
+   *
+   * Fastest rate in milliseconds at which your app can handle location updates.
+   * @see Android docs (https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest.html#getFastestInterval())
+   */
+  fastestInterval?: number;
+
+  /**
+   * ANDROID ONLY with BackgroundGeolocation.LocationProvider.ANDROID_ACTIVITY_PROVIDER
+   *
+   * Rate in milliseconds at which activity recognition occurs. Larger values will result in fewer activity detections while improving battery life.
+   */
+  activitiesInterval?: number;
+
+  /**
+   * ANDROID ONLY with BackgroundGeolocation.LocationProvider.ANDROID_ACTIVITY_PROVIDER
+   *
+   * stop() is forced, when the STILL activity is detected (default is true)
+   */
+  stopOnStillActivity?: boolean;
 }
 
 /**


### PR DESCRIPTION
There seemed to be some discrepancies between the options you could pass in and the ones on the [plugin's github](https://github.com/mauron85/cordova-plugin-background-geolocation) so I updated them