### PR TITLE
Link to cordova-plugin-file

### DIFF
--- a/src/plugins/filetransfer.ts
+++ b/src/plugins/filetransfer.ts
@@ -173,6 +173,10 @@ export interface FileTransferError {
  * cd files
  * ls
  * ```
+ *
+ * To store files in a different/publicly accessible directory, please refer to the following link
+ * https://github.com/apache/cordova-plugin-file#where-to-store-files
+ *
  * @interfaces
  * FileUploadOptions
  * FileUploadResult


### PR DESCRIPTION
Adding a link to **cordova plugin file** for ease of understanding file management using cordova.

It took me almost a day to figure out how to properly save things like a pdf/image in a publicly accessible directory. Having a link to the main **cordova file** documentation will save a lot of time.