### PR TITLE
fix(plugin wrapper): fix #339, should check callback errorIndex is undefined

### DIFF
--- a/src/plugins/pin-dialog.ts
+++ b/src/plugins/pin-dialog.ts
@@ -34,7 +34,8 @@ export class PinDialog {
    * @returns {Promise<{ buttonIndex: number, input1: string }>}
    */
   @Cordova({
-    successIndex: 1
+    successIndex: 1,
+    errorIndex: 4 // we don't need this, so we set it to a value higher than # of args
   })
   static prompt(message: string, title: string, buttons: string[]): Promise<{ buttonIndex: number, input1: string }> { return; }
 


### PR DESCRIPTION
in #339, plugin such as PinDialog, the callback only have successCallback, not errorCallback, so the 
plugin wrapper in ionic-native will throw error or pass wrong parameters into native plugin because errorIndex is undefined here, https://github.com/driftyco/ionic-native/blob/master/src/plugins/plugin.ts#L179