### PR TITLE
chore(): change rxjs version to match ionic framework

### DIFF
--- a/scripts/build/core-package.json.template
+++ b/scripts/build/core-package.json.template
@@ -7,7 +7,7 @@
   "author": "ionic",
   "license": "MIT",
   "peerDependencies": {
-    "rxjs": "^5.0.1"
+    "rxjs": "5.0.0-beta.12"
   },
   "repository": {
     "type": "git",

--- a/scripts/build/plugin-package.json.template
+++ b/scripts/build/plugin-package.json.template
@@ -10,7 +10,7 @@
     "@ionic-native/core": "{{VERSION}}"
   },
   "peerDependencies": {
-    "rxjs": "^5.0.1"
+    "rxjs": "5.0.0-beta.12"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
closes #1046 

Or we can update the ionic framework to use the stable version of rxjs,