### PR TITLE
chore(deps): use 5.0.0-beta.12 rxjs

### DIFF
--- a/scripts/build/core-package.json.template
+++ b/scripts/build/core-package.json.template
@@ -7,7 +7,7 @@
   "author": "ionic",
   "license": "MIT",
   "peerDependencies": {
-    "rxjs": "^5.0.1"
+    "rxjs": "5.0.0-beta.12"
   },
   "repository": {
     "type": "git",

--- a/scripts/build/plugin-package.json.template
+++ b/scripts/build/plugin-package.json.template
@@ -10,7 +10,7 @@
     "@ionic-native/core": "{{VERSION}}"
   },
   "peerDependencies": {
-    "rxjs": "^5.0.1"
+    "rxjs": "5.0.0-beta.12"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes an issue with npm complaining with `npm WARN @ionic-native/camera@3.0.0-alpha.1 requires a peer of rxjs@^5.0.1 but none was installed.` when using these modules in an app. The framework is currently on rxjs 5.0.0-beta.12 as that is the version that the version of angular we are currently on wants.