### PR TITLE
feat(inappbrowser): add interface for IAB options

### DIFF
--- a/src/plugins/inappbrowser.ts
+++ b/src/plugins/inappbrowser.ts
@@ -3,6 +3,42 @@ import { Observable } from 'rxjs/Observable';
 
 declare var cordova: any;
 
+export interface InAppBrowserOptions {
+  /** Set to yes or no to ruen the InAppBrowser's location bar on or off. */
+  location?: 'yes' | 'no';
+  /** Set to yes to create the browser and load the page, but not show it. The loadstop event fires when loading is complete.
+   * Omit or set to no (default) to have the browser open and load normally. */
+  hidden?: 'yes' | 'no';
+  /** Set to yes to have the browser's cookie cache cleared before the new window is opened. */
+  clearcache?: 'yes';
+  /** Set to yes to have the session cookie cache cleared before the new window is opened. */
+  clearsessioncache?: 'yes';
+  /** (Android Only) set to yes to show Android browser's zoom controls, set to no to hide them. Default value is yes. */
+  zoom?: 'yes' | 'no';
+  /** Set to yes to use the hardware back button to navigate backwards through the InAppBrowser's history.
+   * If there is no previous page, the InAppBrowser will close. The default value is yes, so you must set it to no if you want the back button to simply close the InAppBrowser. */
+  hardwareback?: 'yes' | 'no';
+  /** Set to yes to prevent HTML5 audio or video from autoplaying (defaults to no). */
+  mediaPlaybackRequiresUserAction?: 'yes' | 'no';
+  /** (Android Only) Set to yes to make InAppBrowser WebView to pause/resume with the app to stop background audio (this may be required to avoid Google Play issues) */
+  shouldPauseOnSuspend?: 'yes' | 'no';
+  /** (iOS Only) Set to yes or no to allow in-line HTML5 media playback, displaying within the browser window rather than a device-specific playback interface.
+   * The HTML's video element must also include the webkit-playsinline attribute (defaults to no) */
+  allowInlineMediaPlayback?: 'yes' | 'no';
+  /** (iOS Only) Set to yes or no to open the keyboard when form elements receive focus via JavaScript's focus() call (defaults to yes). */
+  keyboardDisplayRequiresUserAction?: 'yes' | 'no';
+  /** (iOS Only) Set to yes or no to wait until all new view content is received before being rendered (defaults to no). */
+  suppressesIncrementalRendering?: 'yes' | 'no';
+  /** (iOS Only) Set to pagesheet, formsheet or fullscreen to set the presentation style (defaults to fullscreen). */
+  presentationstyle?: 'pagesheet' | 'formsheet' | 'fullscreen';
+  /** (iOS Only) Set to fliphorizontal, crossdissolve or coververtical to set the transition style (defaults to coververtical). */
+  transitionstyle?: 'fliphorizontal' | 'crossdissolve' | 'coververtical';
+  /** (iOS Only) Set to top or bottom (default is bottom). Causes the toolbar to be at the top or bottom of the window. */
+  toolbarposition?: 'top' | 'bottom';
+  /** (Windows only) Set to yes to create the browser control without a border around it.
+   * Please note that if location=no is also specified, there will be no control presented to user to close IAB window. */
+  fullscreen?: 'yes';
+}
 export interface InAppBrowserEvent extends Event {
   /** the eventname, either loadstart, loadstop, loaderror, or exit. */
   type: string;
@@ -50,7 +86,7 @@ export class InAppBrowser {
    *                 The options string must not contain any blank space, and each feature's
    *                 name/value pairs must be separated by a comma. Feature names are case insensitive.
    */
-  constructor(url: string, target?: string, options?: string) {
+  constructor(url: string, target?: string, options?: InAppBrowserOptions) {
     try {
       this._objectInstance = cordova.InAppBrowser.open(url, target, options);
     } catch (e) {
@@ -63,20 +99,20 @@ export class InAppBrowser {
    * Displays an InAppBrowser window that was opened hidden. Calling this has no effect
    * if the InAppBrowser was already visible.
    */
-  @CordovaInstance({sync: true})
+  @CordovaInstance({ sync: true })
   show(): void { }
 
   /**
    * Closes the InAppBrowser window.
    */
-  @CordovaInstance({sync: true})
+  @CordovaInstance({ sync: true })
   close(): void { }
 
   /**
    * Hides an InAppBrowser window that is currently shown. Calling this has no effect
    * if the InAppBrowser was already hidden.
    */
-  @CordovaInstance({sync: true})
+  @CordovaInstance({ sync: true })
   hide(): void { }
 
   /**
@@ -85,7 +121,7 @@ export class InAppBrowser {
    * @returns {Promise<any>}
    */
   @CordovaInstance()
-  executeScript(script: {file?: string, code?: string}): Promise<any> {return; }
+  executeScript(script: { file?: string, code?: string }): Promise<any> { return; }
 
   /**
    * Injects CSS into the InAppBrowser window.
@@ -93,7 +129,7 @@ export class InAppBrowser {
    * @returns {Promise<any>}
    */
   @CordovaInstance()
-  insertCSS(css: {file?: string, code?: string}): Promise<any> {return; }
+  insertCSS(css: { file?: string, code?: string }): Promise<any> { return; }
 
   /**
    * A method that allows you to listen to events happening in the browser.

--- a/src/plugins/inappbrowser.ts
+++ b/src/plugins/inappbrowser.ts
@@ -22,6 +22,14 @@ export interface InAppBrowserOptions {
   mediaPlaybackRequiresUserAction?: 'yes' | 'no';
   /** (Android Only) Set to yes to make InAppBrowser WebView to pause/resume with the app to stop background audio (this may be required to avoid Google Play issues) */
   shouldPauseOnSuspend?: 'yes' | 'no';
+  /** (iOS Only) Set to a string to use as the Done button's caption. Note that you need to localize this value yourself. */
+  closebuttoncaption?: string;
+  /** (iOS Only) Set to yes or no (default is no). Turns on/off the UIWebViewBounce property. */
+  disallowoverscroll?: 'yes' | 'no';
+  /** (iOS Only) Set to yes or no to turn the toolbar on or off for the InAppBrowser (defaults to yes) */
+  toolbar?: 'yes' | 'no';
+  /** (iOS Only)  Set to yes or no to prevent viewport scaling through a meta tag (defaults to no). */
+  enableViewportScale?: 'yes' | 'no';
   /** (iOS Only) Set to yes or no to allow in-line HTML5 media playback, displaying within the browser window rather than a device-specific playback interface.
    * The HTML's video element must also include the webkit-playsinline attribute (defaults to no) */
   allowInlineMediaPlayback?: 'yes' | 'no';

--- a/src/plugins/inappbrowser.ts
+++ b/src/plugins/inappbrowser.ts
@@ -86,8 +86,12 @@ export class InAppBrowser {
    *                 The options string must not contain any blank space, and each feature's
    *                 name/value pairs must be separated by a comma. Feature names are case insensitive.
    */
-  constructor(url: string, target?: string, options?: InAppBrowserOptions) {
+  constructor(url: string, target?: string, options?: InAppBrowserOptions);
+  constructor(url: string, target?: string, options?: string);
+  constructor(url: string, target?: string, options?: string | InAppBrowserOptions) {
     try {
+      if (options && typeof options !== 'string')
+        options = Object.keys(options).map(key => `${key}=${options[key]}`).join(',');
       this._objectInstance = cordova.InAppBrowser.open(url, target, options);
     } catch (e) {
       window.open(url);

--- a/test/plugins/inappbrowser.spec.ts
+++ b/test/plugins/inappbrowser.spec.ts
@@ -13,8 +13,18 @@ describe('InAppBrowser', () => {
 	const options: InAppBrowserOptions = { hidden: 'yes', hardwareback: 'no' };
 	let object;
 
-	it('should create an object', () => {
-		object = new InAppBrowser("http://google.com", "_self", options);
-		expect(true).toBeDefined();
+	it('should create an object using strings and InAppBrowserOptions signature', () => {
+		object = new InAppBrowser('http://google.com', '_self', options);
+		expect(object).toBeDefined();
+	});
+
+	it('should create an object using string only signature', () => {
+		object = new InAppBrowser('http://google.com', '_self', 'location=no');
+		expect(object).toBeDefined();
+	});
+
+	it('should create an object with the least amount of parameters', () => {
+		object = new InAppBrowser('http://google.com');
+		expect(object).toBeDefined();
 	});
 });

--- a/test/plugins/inappbrowser.spec.ts
+++ b/test/plugins/inappbrowser.spec.ts
@@ -1,0 +1,20 @@
+import { InAppBrowser, InAppBrowserEvent, InAppBrowserOptions } from '../../src/plugins/inappbrowser';
+
+declare var window: any;
+
+window.cordova = {
+	InAppBrowser: {
+		open: window.open
+	}
+};
+
+describe('InAppBrowser', () => {
+
+	const options: InAppBrowserOptions = { hidden: 'yes', hardwareback: 'no' };
+	let object;
+
+	it('should create an object', () => {
+		object = new InAppBrowser("http://google.com", "_self", options);
+		expect(true).toBeDefined();
+	});
+});


### PR DESCRIPTION
One of the bigger annoyances working with the InAppBrowser is the fallibility of the options string. To mitigate that, I added a new interface, `InAppBrowserOptions`, that an object can cast itself to and be provided tooling on what keys and values are supported.

To that extent, I've overloaded the constructor and if the `options` parameter comes in as an `InAppBrowserOptions`, I map the key-value pairs into a string that is consumable by the Cordova plugin.