### PR TITLE
Added UniqueDeviceId plugin support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,7 @@ import { TouchID } from './plugins/touchid';
 import { TextToSpeech } from './plugins/text-to-speech';
 import { ThemeableBrowser } from './plugins/themeable-browser';
 import { TwitterConnect } from './plugins/twitter-connect';
+import { UniqueDeviceID } from './plugins/unique-device-id';
 import { Vibration } from './plugins/vibration';
 import { VideoEditor } from './plugins/video-editor';
 import { VideoPlayer } from './plugins/video-player';
@@ -240,6 +241,7 @@ export * from './plugins/themeable-browser';
 export * from './plugins/toast';
 export * from './plugins/touchid';
 export * from './plugins/twitter-connect';
+export * from './plugins/unique-device-id';
 export * from './plugins/vibration';
 export * from './plugins/video-editor';
 export * from './plugins/video-player';
@@ -364,6 +366,7 @@ window['IonicNative'] = {
   TextToSpeech,
   ThemeableBrowser,
   TwitterConnect,
+  UniqueDeviceID,
   VideoEditor,
   VideoPlayer,
   Vibration,

--- a/src/plugins/unique-device-id.ts
+++ b/src/plugins/unique-device-id.ts
@@ -1,0 +1,35 @@
+import { Plugin, Cordova } from './plugin';
+
+/**
+ * @name UniqueDeviceID
+ * @description
+ * This plugin produces a unique, cross-install, app-specific device id.
+ *
+ * @usage
+ * ```
+ * import { UniqueDeviceID } from 'ionic-native';
+ *
+ * UniqueDeviceID.get()
+ *   .then((uuid: any) => doSomething(uuid))
+ *   .catch((error: any) => console.log(error));
+ *
+ * ```
+ */
+@Plugin({
+  pluginName: 'UniqueDeviceID',
+  plugin: 'cordova-plugin-uniquedeviceid', // npm package name, example: cordova-plugin-camera
+  pluginRef: 'window.plugins.uniqueDeviceID', // the variable reference to call the plugin, example: navigator.geolocation
+  repo: 'https://github.com/Paldom/UniqueDeviceID' // the github repository URL for the plugin
+})
+export class UniqueDeviceID {
+
+  /**
+   * Gets a unique, cross-install, app-specific device id.
+   * @return {Promise<string>} Returns a promise that resolves when something happens
+   */
+  @Cordova()
+  static get(): Promise<string> {
+    return; // We add return; here to avoid any IDE / Compiler errors
+  }
+
+}


### PR DESCRIPTION
This plugin is similar to how `device.uuid` works, except that it is iOS 6+ compatible by creating a uuid in the keychain to persist between app installs.