### PR TITLE
Docs for devicemotion.ts updated

### DIFF
--- a/src/plugins/devicemotion.ts
+++ b/src/plugins/devicemotion.ts
@@ -41,17 +41,17 @@ export interface DeviceMotionAccelerometerOptions {
  *
  * @usage
  * ```typescript
- * import { DeviceMotion } from 'ionic-native';
+ * import { DeviceMotion, DeviceMotionAccelerationData } from 'ionic-native';
  *
  *
  * // Get the device current acceleration
  * DeviceMotion.getCurrentAcceleration().then(
- *   (acceleration: AccelerationData) => console.log(acceleration),
+ *   (acceleration: DeviceMotionAccelerationData) => console.log(acceleration),
  *   (error: any) => console.log(error)
  * );
  *
  * // Watch device acceleration
- * var subscription = DeviceMotion.watchAcceleration().subscribe((acceleration: AccelerationData) => {
+ * var subscription = DeviceMotion.watchAcceleration().subscribe((acceleration: DeviceMotionAccelerationData) => {
  *   console.log(acceleration);
  * });
  *


### PR DESCRIPTION
AccelerationData interface is wrongly named in docs. It should be DeviceMotionAccelerationData. And I added it to import statement.