### PR TITLE
Add matching support for local notification icon background color

### DIFF
--- a/src/plugins/localnotifications.ts
+++ b/src/plugins/localnotifications.ts
@@ -64,6 +64,13 @@ export interface ILocalNotification {
    * Default: res://ic_popup_reminder
    */
   smallIcon?: string;
+  
+  /**
+  * ANDROID ONLY
+  * RGB value for the background color of the smallIcon. 
+  * Default: Androids COLOR_DEFAULT, which will vary based on Android version.
+  */
+  color?: string;
 
 
   /**


### PR DESCRIPTION
The Cordova plugin Ionic Natives uses allows specifying the background color of the smallIcon.  By not including it in your interface you force users to use the default color for their version of Android.  While the LocalNotification plugin is not well documented, it does include this feature, see Options.java line 253:

```
/**
     * @return
     *      The notification background color for the small icon
     *      Returns null, if no color is given.
     */
    public int getColor() {
        String hex = options.optString("color", null);

        if (hex == null) {
            return NotificationCompat.COLOR_DEFAULT;
        }

        int aRGB = Integer.parseInt(hex, 16);

        return aRGB + 0xFF000000;
    }
```

I've simply added the option to the interface as well as a short description.

This lets you go from the default color (varies by Android version): https://goo.gl/photos/nERcj4GZgapy8aee9
To any color you'd like: https://goo.gl/photos/t8V9WVba8jDU49aHA
And also works if you also specify a large icon: https://goo.gl/photos/gWQYwa12djmdXfYcA