### PR TITLE
fix(File): Platform Browser will raise a an DOMException

### DIFF
--- a/src/plugins/file.ts
+++ b/src/plugins/file.ts
@@ -960,6 +960,9 @@ export class File {
    * @private
    */
   private static fillErrorMessage(err: FileError): void {
+    if (typeof err === "DOMException") {
+      return;
+    }
     err.message = File.cordovaFileError[err.code];
   }
 


### PR DESCRIPTION
fix(File): Platform Browser will raise a an DOMException on resoleLocalFilesystemUrl and tries to write on readonly property DOMException err.message in fillErrorMessage