### PR TITLE
Added in a constant for MapTypeId in GoogleMaps

### DIFF
--- a/src/plugins/googlemap.ts
+++ b/src/plugins/googlemap.ts
@@ -37,6 +37,15 @@ export const GoogleMapsAnimation = {
   DROP: 'DROP'
 };
 
+export const GoogleMapsMapTypeId = {
+    HYBRID: 'MAP_TYPE_HYBRID',
+    NONE: 'MAP_TYPE_NONE',
+    NORMAL: 'MAP_TYPE_NORMAL',
+    ROADMAP: 'MAP_TYPE_ROADMAP',
+    SATELLITE: 'MAP_TYPE_SATELLITE',
+    TERAIN: 'MAP_TYPE_TERRAIN'
+};
+
 /**
  * @name Google Maps
  * @description This plugin uses the native Google Maps SDK
@@ -48,7 +57,8 @@ export const GoogleMapsAnimation = {
  *  GoogleMapsLatLng,
  *  CameraPosition,
  *  GoogleMapsMarkerOptions,
- *  GoogleMapsMarker
+ *  GoogleMapsMarker,
+ *  GoogleMapsMapTypeId
  * } from 'ionic-native';
  *
  * export class MapPage {
@@ -258,7 +268,7 @@ export class GoogleMap {
   setZoom(zoomLevel: number): void { }
 
   @CordovaInstance({ sync: true })
-  setMapTypeId(typeId: string): void { }
+  setMapTypeId(mapTypeId: string): void { }
 
   @CordovaInstance({ sync: true })
   setTilt(tiltLevel: number): void { }


### PR DESCRIPTION
Now matches: https://developers.google.com/maps/documentation/javascript/3.exp/reference#MapTypeId

Example...

import { GoogleMap, GoogleMapsEvent, GoogleMapsLatLng, GoogleMapsMapTypeId } from 'ionic-native';

        this.map = new GoogleMap('map', {
          'backgroundColor': 'white',
          'mapType': GoogleMapsMapTypeId.HYBRID,
          'controls': {
            'compass': true,
            'myLocationButton': true,
            'indoorPicker': true,
            'zoom': true
          },
          'gestures': {
            'scroll': true,
            'tilt': true,
            'rotate': true,
            'zoom': true
          },
          'camera': {
            'latLng': location,
            'tilt': 30,
            'zoom': 15,
            'bearing': 50
          }
        });