### PR TITLE
fix(File): typing where `FileError` can be thrown

### DIFF
--- a/src/plugins/file.ts
+++ b/src/plugins/file.ts
@@ -407,9 +407,9 @@ export class File {
    *
    * @param {string} path Base FileSystem. Please refer to the iOS and Android filesystems above
    * @param {string} dir Name of directory to check
-   * @returns {Promise<boolean|FileError>} Returns a Promise that resolves to true if the directory exists or rejects with an error.
+   * @returns {Promise<boolean>} Returns a Promise that resolves to true if the directory exists or rejects with an error.
    */
-  static checkDir(path: string, dir: string): Promise<boolean|FileError> {
+  static checkDir(path: string, dir: string): Promise<boolean> {
     if ((/^\//.test(dir))) {
       let err = new FileError(5);
       err.message = 'directory cannot start with \/';
@@ -431,9 +431,9 @@ export class File {
    * @param {string} path  Base FileSystem. Please refer to the iOS and Android filesystems above
    * @param {string} dirName Name of directory to create
    * @param {boolean} replace If true, replaces file with same name. If false returns error
-   * @returns {Promise<DirectoryEntry|FileError>} Returns a Promise that resolves with a DirectoryEntry or rejects with an error.
+   * @returns {Promise<DirectoryEntry>} Returns a Promise that resolves with a DirectoryEntry or rejects with an error.
    */
-  static createDir(path: string, dirName: string, replace: boolean): Promise<DirectoryEntry|FileError> {
+  static createDir(path: string, dirName: string, replace: boolean): Promise<DirectoryEntry> {
     if ((/^\//.test(dirName))) {
       let err = new FileError(5);
       err.message = 'directory cannot start with \/';
@@ -459,9 +459,9 @@ export class File {
    *
    * @param {string} path The path to the directory
    * @param {string} dirName The directory name
-   * @returns {Promise<RemoveResult|FileError>} Returns a Promise that resolves to a RemoveResult or rejects with an error.
+   * @returns {Promise<RemoveResult>} Returns a Promise that resolves to a RemoveResult or rejects with an error.
    */
-  static removeDir(path: string, dirName: string): Promise<RemoveResult|FileError> {
+  static removeDir(path: string, dirName: string): Promise<RemoveResult> {
     if ((/^\//.test(dirName))) {
       let err = new FileError(5);
       err.message = 'directory cannot start with \/';
@@ -484,9 +484,9 @@ export class File {
    * @param {string} dirName The source directory name
    * @param {string} newPath The destionation path to the directory
    * @param {string} newDirName The destination directory name
-   * @returns {Promise<DirectoryEntry|Entry|FileError>} Returns a Promise that resolves to the new DirectoryEntry object or rejects with an error.
+   * @returns {Promise<DirectoryEntry|Entry>} Returns a Promise that resolves to the new DirectoryEntry object or rejects with an error.
    */
-  static moveDir(path: string, dirName: string, newPath: string, newDirName: string): Promise<DirectoryEntry|Entry|FileError> {
+  static moveDir(path: string, dirName: string, newPath: string, newDirName: string): Promise<DirectoryEntry|Entry> {
     newDirName = newDirName || dirName;
 
     if ((/^\//.test(newDirName))) {
@@ -514,9 +514,9 @@ export class File {
    * @param {string} dirName Name of directory to copy
    * @param {string} newPath Base FileSystem of new location
    * @param {string} newDirName New name of directory to copy to (leave blank to remain the same)
-   * @returns {Promise<Entry|FileError>} Returns a Promise that resolves to the new Entry object or rejects with an error.
+   * @returns {Promise<Entry>} Returns a Promise that resolves to the new Entry object or rejects with an error.
    */
-  static copyDir(path: string, dirName: string, newPath: string, newDirName: string): Promise<Entry|FileError> {
+  static copyDir(path: string, dirName: string, newPath: string, newDirName: string): Promise<Entry> {
     if ((/^\//.test(newDirName))) {
       let err = new FileError(5);
       err.message = 'directory cannot start with \/';
@@ -587,9 +587,9 @@ export class File {
    *
    * @param {string} path Base FileSystem. Please refer to the iOS and Android filesystems above
    * @param {string} file Name of file to check
-   * @returns {Promise<boolean|FileError>} Returns a Promise that resolves with a boolean or rejects with an error.
+   * @returns {Promise<boolean>} Returns a Promise that resolves with a boolean or rejects with an error.
    */
-  static checkFile(path: string, file: string): Promise<boolean|FileError> {
+  static checkFile(path: string, file: string): Promise<boolean> {
     if ((/^\//.test(file))) {
       let err = new FileError(5);
       err.message = 'file cannot start with \/';
@@ -616,9 +616,9 @@ export class File {
    * @param {string} path  Base FileSystem. Please refer to the iOS and Android filesystems above
    * @param {string} fileName Name of file to create
    * @param {boolean} replace If true, replaces file with same name. If false returns error
-   * @returns {Promise<FileEntry|FileError>} Returns a Promise that resolves to a FileEntry or rejects with an error.
+   * @returns {Promise<FileEntry>} Returns a Promise that resolves to a FileEntry or rejects with an error.
    */
-  static createFile(path: string, fileName: string, replace: boolean): Promise<FileEntry|FileError> {
+  static createFile(path: string, fileName: string, replace: boolean): Promise<FileEntry> {
     if ((/^\//.test(fileName))) {
       let err = new FileError(5);
       err.message = 'file-name cannot start with \/';
@@ -644,9 +644,9 @@ export class File {
    *
    * @param {string} path  Base FileSystem. Please refer to the iOS and Android filesystems above
    * @param {string} fileName Name of file to remove
-   * @returns {Promise<RemoveResult|FileError>} Returns a Promise that resolves to a RemoveResult or rejects with an error.
+   * @returns {Promise<RemoveResult>} Returns a Promise that resolves to a RemoveResult or rejects with an error.
    */
-  static removeFile(path: string, fileName: string): Promise<RemoveResult|FileError> {
+  static removeFile(path: string, fileName: string): Promise<RemoveResult> {
     if ((/^\//.test(fileName))) {
       let err = new FileError(5);
       err.message = 'file-name cannot start with \/';
@@ -733,9 +733,9 @@ export class File {
    *
    * @param {string} path Base FileSystem. Please refer to the iOS and Android filesystems above
    * @param {string} file Name of file, relative to path.
-   * @returns {Promise<string|FileError>} Returns a Promise that resolves with the contents of the file as string or rejects with an error.
+   * @returns {Promise<string>} Returns a Promise that resolves with the contents of the file as string or rejects with an error.
    */
-  static readAsText(path: string, file: string): Promise<string|FileError> {
+  static readAsText(path: string, file: string): Promise<string> {
     if ((/^\//.test(file))) {
       let err = new FileError(5);
       err.message = 'file-name cannot start with \/';
@@ -774,9 +774,9 @@ export class File {
 
    * @param {string} path Base FileSystem. Please refer to the iOS and Android filesystems above
    * @param {string} file Name of file, relative to path.
-   * @returns {Promise<string|FileError>} Returns a Promise that resolves with the contents of the file as data URL or rejects with an error.
+   * @returns {Promise<string>} Returns a Promise that resolves with the contents of the file as data URL or rejects with an error.
    */
-  static readAsDataURL(path: string, file: string): Promise<string|FileError> {
+  static readAsDataURL(path: string, file: string): Promise<string> {
     if ((/^\//.test(file))) {
       let err = new FileError(5);
       err.message = 'file-name cannot start with \/';
@@ -816,9 +816,9 @@ export class File {
 
    * @param {string} path Base FileSystem. Please refer to the iOS and Android filesystems above
    * @param {string} file Name of file, relative to path.
-   * @returns {Promise<string|FileError>} Returns a Promise that resolves with the contents of the file as string rejects with an error.
+   * @returns {Promise<string>} Returns a Promise that resolves with the contents of the file as string rejects with an error.
    */
-  static readAsBinaryString(path: string, file: string): Promise<string|FileError> {
+  static readAsBinaryString(path: string, file: string): Promise<string> {
     if ((/^\//.test(file))) {
       let err = new FileError(5);
       err.message = 'file-name cannot start with \/';
@@ -857,9 +857,9 @@ export class File {
 
    * @param {string} path Base FileSystem. Please refer to the iOS and Android filesystems above
    * @param {string} file Name of file, relative to path.
-   * @returns {Promise<ArrayBuffer|FileError>} Returns a Promise that resolves with the contents of the file as ArrayBuffer or rejects with an error.
+   * @returns {Promise<ArrayBuffer>} Returns a Promise that resolves with the contents of the file as ArrayBuffer or rejects with an error.
    */
-  static readAsArrayBuffer(path: string, file: string): Promise<ArrayBuffer|FileError> {
+  static readAsArrayBuffer(path: string, file: string): Promise<ArrayBuffer> {
     if ((/^\//.test(file))) {
       let err = new FileError(5);
       err.message = 'file-name cannot start with \/';
@@ -900,9 +900,9 @@ export class File {
    * @param {string} fileName Name of file to move
    * @param {string} newPath Base FileSystem of new location
    * @param {string} newFileName New name of file to move to (leave blank to remain the same)
-   * @returns {Promise<Entry|FileError>} Returns a Promise that resolves to the new Entry or rejects with an error.
+   * @returns {Promise<Entry>} Returns a Promise that resolves to the new Entry or rejects with an error.
    */
-  static moveFile(path: string, fileName: string, newPath: string, newFileName: string): Promise<Entry|FileError> {
+  static moveFile(path: string, fileName: string, newPath: string, newFileName: string): Promise<Entry> {
     newFileName = newFileName || fileName;
 
     if ((/^\//.test(newFileName))) {
@@ -930,9 +930,9 @@ export class File {
    * @param {string} fileName Name of file to copy
    * @param {string} newPath Base FileSystem of new location
    * @param {string} newFileName New name of file to copy to (leave blank to remain the same)
-   * @returns {Promise<Entry|FileError>} Returns a Promise that resolves to an Entry or rejects with an error.
+   * @returns {Promise<Entry>} Returns a Promise that resolves to an Entry or rejects with an error.
    */
-  static copyFile(path: string, fileName: string, newPath: string, newFileName: string): Promise<Entry|FileError> {
+  static copyFile(path: string, fileName: string, newPath: string, newFileName: string): Promise<Entry> {
     newFileName = newFileName || fileName;
 
     if ((/^\//.test(newFileName))) {


### PR DESCRIPTION
Promises that reject with a `FileError` are not of the type `Promise<T|FileError>`, but `Promise<T>`.

The previous declarations of `Promise<T|FileError>` would break typing further down the chain where you are trying to use the value that the typing says could be `T|FileError` but in reality could only be `T`.

```ts
File.readFileAsText(cordova.file.dataDirectory, 'some.json')
    .then(json => JSON.parse(json));
```

This would result in `Argument of type 'string | FileError' is not assignable to parameter of type 'string'. Type 'FileError' is not assignable to type 'string'.'`