### PR TITLE
add the missing cordova push android push option clearBadge

### DIFF
--- a/src/plugins/push.ts
+++ b/src/plugins/push.ts
@@ -276,6 +276,11 @@ export interface AndroidPushOptions {
   vibrate?: boolean | string;
 
   /**
+   * If true the icon badge will be cleared on init and before push messages are processed.
+   */
+  clearBadge?: boolean | string;
+
+  /**
    * If true the app clears all pending notifications when it is closed.
    */
   clearNotifications?: boolean | string;


### PR DESCRIPTION
according to https://github.com/phonegap/phonegap-plugin-push/blob/master/docs/API.md#parameters, there is one clearBadge option in Android push options, which is missing in the ionic native push module interface at the moment.