### PR TITLE
Fix default facebook logEvent parameters

### DIFF
--- a/src/plugins/facebook.ts
+++ b/src/plugins/facebook.ts
@@ -232,11 +232,14 @@ export class Facebook {
    * @param {number}  [valueToSum] any value to be added to added to a sum on each event
    * @returns {Promise<any>}
    */
-  @Cordova()
+  @Cordova({
+    successIndex: 3,
+    errorIndex: 4
+  })
   static logEvent(
     name: string,
-    params: Object = null,
-    valueToSum: number = null
+    params?: Object,
+    valueToSum?: number
     ): Promise<any> { return; }
 
   /**

--- a/src/plugins/facebook.ts
+++ b/src/plugins/facebook.ts
@@ -235,8 +235,8 @@ export class Facebook {
   @Cordova()
   static logEvent(
     name: string,
-    params?: Object,
-    valueToSum?: number
+    params: Object = null,
+    valueToSum: number = null
     ): Promise<any> { return; }
 
   /**


### PR DESCRIPTION
It is necessary to have default values when calling Facebook.logEvent() instead of optional parameters. This is necessary because calling this method without any of the optional parameters, causes a bug where the second and third parameter are the callbacks instead of "null" or "undefined".

I am not sure if this is the case for any plugin using the optional parameter notation instead of default value, but I can confirm this one because it created a bug in my application.