### PR TITLE
Improve ionic-native maps documentation

### DIFF
--- a/src/plugins/googlemap.ts
+++ b/src/plugins/googlemap.ts
@@ -71,9 +71,6 @@ export const GoogleMapsAnimation = {
  *
  *  let map = new GoogleMap(element);
  *
- *  // listen to MAP_READY event
- *  map.one(GoogleMapsEvent.MAP_READY).then(() => console.log('Map is ready!'));
- *
  *  // create LatLng object
  *  let ionic: GoogleMapsLatLng = new GoogleMapsLatLng(43.0741904,-89.3809802);
  *
@@ -84,9 +81,13 @@ export const GoogleMapsAnimation = {
  *    tilt: 30
  *  };
  *
- *  // move the map's camera to position
- *  map.moveCamera(position);
+ *  // listen to MAP_READY event
+ *  map.one(GoogleMapsEvent.MAP_READY).then(() => {
+ *    // move the map's camera to position
+ *    map.moveCamera(position); // works on iOS and Android
+ * });
  *
+ *  
  *  // create new marker
  *  let markerOptions: GoogleMapsMarkerOptions = {
  *    position: ionic,


### PR DESCRIPTION
Inside  ionic-native maps documentation : moved `map.moveCamera(position);` **inside the MAP_READY event.** 

**Short description of what this resolves :**
Fix zoom on first launch on Android device. 

**Changes proposed in this pull request :**
moved `map.moveCamera(position);` inside the MAP_READY event. 
