### PR TITLE
fix(imagepicker): add outputType option

### DIFF
--- a/src/plugins/imagepicker.ts
+++ b/src/plugins/imagepicker.ts
@@ -20,6 +20,11 @@ export interface ImagePickerOptions {
    * Quality of images, defaults to 100
    */
   quality?: number;
+
+  /**
+   * Output type, defaults to 0  (FILE_URI).
+   */
+  outputType?: number;
 }
 
 /**


### PR DESCRIPTION
add new outputType option. 

```
    // output type, defaults to FILE_URIs.
    // available options are 
    // window.imagePicker.OutputType.FILE_URI (0) or 
    // window.imagePicker.OutputType.BASE64_STRING (1)
    outputType: int
```