### PR TITLE
Update ibeacon.ts

### DIFF
--- a/src/plugins/ibeacon.ts
+++ b/src/plugins/ibeacon.ts
@@ -546,11 +546,11 @@ export class IBeacon {
   /**
    * Queries the native layer to determine the current authorization in effect.
    *
-   * @returns {Promise<any>} Returns a promise which is resolved with the
+   * @returns {Promise<IBeaconPluginResult>} Returns a promise which is resolved with the
    * requested authorization status.
    */
   @Cordova({otherPromise: true})
-  static getAuthorizationStatus(): Promise<any> { return; }
+  static getAuthorizationStatus(): Promise<IBeaconPluginResult> { return; }
 
   /**
    * For iOS 8 and above only. The permission model has changed by Apple in iOS 8, making it necessary for apps to


### PR DESCRIPTION
Return type of `getAuthorizationStatus()` made more explicit.