### PR TITLE
fix(plugin): fix #1001, screen-orientation 1.4.2 lockOrientation not return promise.

### DIFF
--- a/src/plugins/screen-orientation.ts
+++ b/src/plugins/screen-orientation.ts
@@ -48,11 +48,10 @@ export class ScreenOrientation {
   /**
    * Lock the orientation to the passed value.
    * See below for accepted values
-   * @param orientation {string} The orientation which should be locked. Accepted values see table below.
-   * @returns {Promise<any>} returns a promise that resolves when the screen orientation is locked, and rejects when an error occurs.
+   * @param orientation {string} The orientation which should be locked. Accepted values see table above.
    */
-  @Cordova({ otherPromise: true })
-  static lockOrientation(orientation: string): Promise<string> { return; }
+  @Cordova({ sync: true })
+  static lockOrientation(orientation: string): void { }
 
   /**
    * Unlock and allow all orientations.


### PR DESCRIPTION
Screen Orientation version 1.4.2 's API
```javascript
 lockOrientation() {}
```
not return promise, it return void.

Screen Orientation version 2.0's API changes the API to 

```javascript
 lock(orientation): Promise<any>();
```

both name and return type changed.

but it is not been released to npm, so ionic native should handle 1.4.2 API correctly
