### PR TITLE
fix typing of "items" member in PayPalPayment

### DIFF
--- a/src/plugins/pay-pal.ts
+++ b/src/plugins/pay-pal.ts
@@ -193,7 +193,7 @@ export class PayPalPayment {
   /**
    * Optional array of PayPalItem objects.
    */
-  items: string;
+  items: Array<PayPalItem>;
 
   /**
    * Optional customer shipping address, if your app wishes to provide this to the SDK.


### PR DESCRIPTION
Type of items should be Array<PayPalItem> instead of string.