### PR TITLE
fix(serial): Serial.requestPermission() options are optional

### DIFF
--- a/src/plugins/serial.ts
+++ b/src/plugins/serial.ts
@@ -23,13 +23,9 @@ export interface SerialOpenOptions {
  * ```
  * import { Serial } from 'ionic-native';
  *
- * Serial.requestPermission({
- *   vid: '0403',
- *   pid: '6001',
- *   driver: 'FtdiSerialDriver'
- * }).then(() => {
+ * Serial.requestPermission().then(() => {
  *   Serial.open({
- *     baudRate: 38400
+ *     baudRate: 9800
  *   }).then(() => {
  *     console.log('Serial connection opened');
  *   });
@@ -49,11 +45,11 @@ export class Serial {
   /**
    * Request permission to connect to a serial device
    *
-   * @param options {SerialPermissionOptions} Options used to request serial permissions
+   * @param options {SerialPermissionOptions} Options used to request serial permissions for an unknown device
    * @return {Promise<any>} Returns a promise that resolves when permissions are granted
    */
   @Cordova()
-  static requestPermission(options: SerialPermissionOptions): Promise<any> { return; }
+  static requestPermission(options?: SerialPermissionOptions): Promise<any> { return; }
 
   /**
    * Open connection to a serial device


### PR DESCRIPTION
The `options` parameter of `Serial.requestPermission()` is entirely optional, and is only to be used as a last resort if a specific device is not (yet) included in the usb-serial-for-android library: https://github.com/xseignard/cordovarduino#your-device-is-not-yet-known.

This should be a rather uncommon case, and the plugin's documentation does not mention the `options` parameter in its introductory examples, so documentation was also slightly adapted.
