### PR TITLE
fingerprint-aio: setting 'use backup' as optional for android only.

### DIFF
--- a/src/plugins/fingerprint-aio.ts
+++ b/src/plugins/fingerprint-aio.ts
@@ -11,6 +11,11 @@ export interface FingerprintOptions {
    * Secret password. Only for android
    */
   clientSecret?: string;
+
+  /**
+   * Disable 'use backup' option. Only for android (optional)
+   */
+  disableBackup?: boolean;
 }
 
 /**
@@ -26,7 +31,8 @@ export interface FingerprintOptions {
  *
  * FingerprintAIO.show({
  *     clientId: "Fingerprint-Demo",
- *    clientSecret: "password" //Only necessary for Android
+ *     clientSecret: "password", //Only necessary for Android
+ *     disableBackup:true  //Only for Android(optional)
  * })
  * .then((result: any) => console.log(any))
  * .catch((error: any) => console.log(error));


### PR DESCRIPTION
fingerprint-aio: setting 'use backup' as optional for android only.
