### PR TITLE
added moveToBackground and moveToForeground

### DIFF
--- a/src/plugins/backgroundmode.ts
+++ b/src/plugins/backgroundmode.ts
@@ -124,6 +124,24 @@ export class BackgroundMode {
   static on(event: string): Observable<any> { return; }
 
   /**
+   * Android allows to programmatically move from foreground to background.
+   */
+  @Cordova({
+    platforms: ['Android'],
+    sync: true
+  })
+  static moveToBackground(): void {}
+
+  /**
+   * Android allows to programmatically move from background to foreground.
+   */
+  @Cordova({
+    platforms: ['Android'],
+    sync: true
+  })
+  static moveToForeground(): void {}
+
+  /**
    * Override the back button on Android to go to background instead of closing the app.
    */
   @Cordova({


### PR DESCRIPTION
feat(background-mode): add missing functions moveToBackground and moveToForeground as explained in https://github.com/driftyco/ionic-native/issues/1180

Please can you add the following 2 functions into background mode:

cordova.plugins.backgroundMode.moveToBackground();
// or
cordova.plugins.backgroundMode.moveToForeground();
Found here:
https://github.com/katzer/cordova-plugin-background-mode#transit-between-application-states

The reason being is that overrideBackButton (https://github.com/driftyco/ionic-native/blob/master/src/plugins/backgroundmode.ts#L133) works really badly for opened nav pages. Instead of going back to the root it closes the App. However moveToBackground works perfectly when required without interfering with the hardware back button.