### PR TITLE
Added function to read RSSI value to the ble plugin wrapper

### DIFF
--- a/src/plugins/ble.ts
+++ b/src/plugins/ble.ts
@@ -423,4 +423,15 @@ export class BLE {
   @Cordova()
   static enable(): Promise<any> { return; }
 
+  /**
+   * Read the RSSI value on the device connection.
+   *
+   * @param {string} deviceId  UUID or MAC address of the peripheral
+   *
+   *@returns {Promise<any>}
+   */
+  @Cordova()
+  static readRSSI(
+    deviceId: string,
+  ): Promise<any> { return; }
 }


### PR DESCRIPTION
In the ble-central-plugin native plugin, the readRSSI method was missing in the wrapper, more info here:
https://github.com/don/cordova-plugin-ble-central/issues/338