### PR TITLE
fixed syntax error in docs example

### DIFF
--- a/src/plugins/googlemap.ts
+++ b/src/plugins/googlemap.ts
@@ -112,7 +112,6 @@ export const GoogleMapsMapTypeId = {
  *       marker.showInfoWindow();
  *     });
  *  }
- * });
  * }
  * ```
  */


### PR DESCRIPTION
fixed syntax error caused by mismatched parentheses and braces in the description