### PR TITLE
Added music controls options for music-controls

### DIFF
--- a/src/plugins/music-controls.ts
+++ b/src/plugins/music-controls.ts
@@ -10,6 +10,9 @@ export interface MusicControlsOptions {
   hasPrev: boolean;
   hasNext: boolean;
   hasClose: boolean;
+  album:string;
+  duration: number;
+  elapsed:number;
   ticker: string;
 }
 
@@ -37,7 +40,12 @@ export interface MusicControlsOptions {
  *   hasPrev   : false,      // show previous button, optional, default: true
  *   hasNext   : false,      // show next button, optional, default: true
  *   hasClose  : true,       // show close button, optional, default: false
- *
+ *  
+ * // iOS only, optional
+ *   album       : 'Absolution'     // optional, default: ''
+ *   duration : 60, // optional, default: 0
+ *   elapsed : 10, // optional, default: 0 
+ * 
  *   // Android only, optional
  *   // text displayed in the status bar when the notification (and the ticker) are updated
  *   ticker    : 'Now playing "Time is Running Out"'


### PR DESCRIPTION
There are more options available for iOS in https://github.com/homerours/cordova-music-controls-plugin. I have added Album name, duration and elapsed time to address added options. 