### PR TITLE
fix(media-plugin): MediaPlugin.create promise never fires

### DIFF
--- a/src/@ionic-native/plugins/media/index.ts
+++ b/src/@ionic-native/plugins/media/index.ts
@@ -14,7 +14,7 @@ export class MediaObject {
    * @param src {string} A URI containing the audio content.
    * @param onStatusUpdate {Function} A callback function to be invoked when the status of the file changes
    */
-  constructor(private _objectInstnace: any) {}
+  constructor(private _objectInstance: any) {}
 
   /**
    * Get the current amplitude of the current recording.
@@ -256,7 +256,8 @@ export class MediaPlugin {
       // Creates a new media object
       // Resolves with the media object
       // or rejects with the error
-      const instance = new Media(src, () => resolve(new Media(instance)), reject, onStatusUpdate);
+      const instance = new Media(src, resolve, reject, onStatusUpdate);
+      return resolve(new MediaObject(instance));
     });
 
   }


### PR DESCRIPTION
The plugin was not working at all.

I think these are the reasons why:
1. There was a typo in MediaObject constructor
2. The MediaPlugin.create promise was never executed
3. The return object was not a MediaObject

I have tested these changes in one of my projects using startRecord, stopRecord and play functions.
I think the rest are also working. Test it before merging this pull request.