### PR TITLE
Change 'any' to 'result' in documentation

### DIFF
--- a/src/@ionic-native/plugins/fingerprint-aio/index.ts
+++ b/src/@ionic-native/plugins/fingerprint-aio/index.ts
@@ -39,7 +39,7 @@ export interface FingerprintOptions {
  *     clientSecret: "password", //Only necessary for Android
  *     disableBackup:true  //Only for Android(optional)
  * })
- * .then((result: any) => console.log(any))
+ * .then((result: any) => console.log(result))
  * .catch((error: any) => console.log(error));
  *
  * ```


### PR DESCRIPTION
In the documentation, when calling `show()`, you logged 'any' in the console, instead of logging 'result'