### PR TITLE
feat(zeroconf): add cordova-plugin-zeroconf support

### DIFF
--- a/src/@ionic-native/plugins/zeroconf/index.ts
+++ b/src/@ionic-native/plugins/zeroconf/index.ts
@@ -1,0 +1,132 @@
+import { Injectable } from '@angular/core';
+import { Cordova, Plugin } from '@ionic-native/core';
+import { Observable } from 'rxjs/Observable';
+
+export interface ZeroconfService {
+  domain: string;
+  type: string;
+  name: string;
+  port: number;
+  hostname: string;
+  ipv4Addresses: Array<string>;
+  ipv6Addresses: Array<string>;
+  txtRecord: any;
+}
+
+export interface ZeroconfResult {
+  action: 'registered' | 'added' | 'removed';
+  service: ZeroconfService;
+}
+
+/**
+ * @name Zeroconf
+ * @description
+ * This plugin allows you to browse and publish Zeroconf/Bonjour/mDNS services.
+ * @usage
+ * ```typescript
+ * import { Zeroconf } from '@ionic-native/zeroconf';
+ *
+ * constructor(private zeroconf: Zeroconf) { }
+ *
+ * ...
+ * ```
+ */
+@Plugin({
+  pluginName: 'Zeroconf',
+  plugin: 'cordova-plugin-zeroconf',
+  pluginRef: 'cordova.plugins.zeroconf',
+  repo: 'https://github.com/becvert/cordova-plugin-zeroconf'
+})
+@Injectable()
+export class Zeroconf {
+  /**
+   * Returns this device's hostname.
+   * @return {Promise<string>}
+   */
+  @Cordova()
+  getHostname(): Promise<string> { return; }
+
+  /**
+   * Publishes a new service.
+   * @usage
+   * ```typescript
+   * this.zeroconf.register('_http._tcp.', 'local.', 'Becvert\'s iPad', 80, {
+   *   'foo': 'bar'
+   * }).then(result => {
+   *   console.log('Service registered', result.service);
+   * });
+   * ```
+   * @param type {string} Service type name, e.g. "_http._tcp".
+   * @param domain {string} Domain scope of the service, typically "local.".
+   * @param name {string} Unqualified service instance name.
+   * @param port {number} Local port on which the service runs.
+   * @param txtRecord {any} Arbitrary key/value pairs describing the service.
+   * @return {Promise<ZeroconfResult>} Returns a Promise that resolves with the registered service.
+   */
+  @Cordova()
+  register(type: string, domain: string, name: string, port: number, txtRecord: any): Promise<ZeroconfResult> { return; }
+
+  /**
+   * Unregisters a service.
+   * @usage
+   * ```typescript
+   * this.zeroconf.unregister('_http._tcp.', 'local.', 'Becvert\'s iPad');
+   * ```
+   * @param type {string} Service type name, e.g. "_http._tcp".
+   * @param domain {string} Domain scope of the service, typically "local.".
+   * @param name {string} Unqualified service instance name.
+   * @return {Promise<void>}
+   */
+  @Cordova()
+  unregister(type: string, domain: string, name: string): Promise<void> { return; }
+
+  /**
+   * Unregisters all published services.
+   * @return {Promise<void>}
+   */
+  @Cordova()
+  stop(): Promise<void> { return; }
+
+  /**
+   * Starts watching for services of the specified type.
+   * @usage
+   * ```typescript
+   * this.zeroconf.watch('_http._tcp.', 'local.').subscribe(result => {
+   *   if (result.action == 'added') {
+   *     console.log('service added', result.service);
+   *   } else {
+   *     console.log('service removed', result.service);
+   *   }
+   * });
+   * ```
+   * @param type {string} Service type name, e.g. "_http._tcp".
+   * @param domain {string} Domain scope of the service, typically "local.".
+   * @return {Observable<ZeroconfResult>} Returns an Observable that notifies of each service added or removed.
+   */
+  @Cordova({
+    observable: true,
+    clearFunction: 'unwatch',
+    clearWithArgs: true
+  })
+  watch(type: string, domain: string): Observable<ZeroconfResult> { return; }
+
+  /**
+   * Stops watching for services of the specified type.
+   * @usage
+   * ```typescript
+   * this.zeroconf.unwatch('_http._tcp.', 'local.');
+   * ```
+   * @param type {string} Service type name, e.g. "_http._tcp".
+   * @param domain {string} Domain scope of the service, typically "local.".
+   * @return {Promise<void>}
+   */
+  @Cordova()
+  unwatch(type: string, domain: string): Promise<void> { return; }
+
+  /**
+   * Closes the service browser and stops watching.
+   * @return {Promise<void>}
+   */
+  @Cordova()
+  close(): Promise<void> { return; }
+}

--- a/src/@ionic-native/plugins/zeroconf/index.ts
+++ b/src/@ionic-native/plugins/zeroconf/index.ts
@@ -29,6 +29,26 @@ export interface ZeroconfResult {
  * constructor(private zeroconf: Zeroconf) { }
  *
  * ...
+ *
+ * // watch for services of a specified type
+ * this.zeroconf.watch('_http._tcp.', 'local.').subscribe(result => {
+ *   if (result.action == 'added') {
+ *     console.log('service added', result.service);
+ *   } else {
+ *     console.log('service removed', result.service);
+ *   }
+ * });
+ *
+ * // publish a zeroconf service of your own
+ * this.zeroconf.register('_http._tcp.', 'local.', 'Becvert\'s iPad', 80, {
+ *   'foo': 'bar'
+ * }).then(result => {
+ *   console.log('Service registered', result.service);
+ * });
+ *
+ *
+ * // unregister your service
+ * this.zeroconf.unregister('_http._tcp.', 'local.', 'Becvert\'s iPad');
  * ```
  */
 @Plugin({
@@ -48,14 +68,6 @@ export class Zeroconf {
 
   /**
    * Publishes a new service.
-   * @usage
-   * ```typescript
-   * this.zeroconf.register('_http._tcp.', 'local.', 'Becvert\'s iPad', 80, {
-   *   'foo': 'bar'
-   * }).then(result => {
-   *   console.log('Service registered', result.service);
-   * });
-   * ```
    * @param type {string} Service type name, e.g. "_http._tcp".
    * @param domain {string} Domain scope of the service, typically "local.".
    * @param name {string} Unqualified service instance name.
@@ -68,10 +80,6 @@ export class Zeroconf {
 
   /**
    * Unregisters a service.
-   * @usage
-   * ```typescript
-   * this.zeroconf.unregister('_http._tcp.', 'local.', 'Becvert\'s iPad');
-   * ```
    * @param type {string} Service type name, e.g. "_http._tcp".
    * @param domain {string} Domain scope of the service, typically "local.".
    * @param name {string} Unqualified service instance name.
@@ -89,16 +97,6 @@ export class Zeroconf {
 
   /**
    * Starts watching for services of the specified type.
-   * @usage
-   * ```typescript
-   * this.zeroconf.watch('_http._tcp.', 'local.').subscribe(result => {
-   *   if (result.action == 'added') {
-   *     console.log('service added', result.service);
-   *   } else {
-   *     console.log('service removed', result.service);
-   *   }
-   * });
-   * ```
    * @param type {string} Service type name, e.g. "_http._tcp".
    * @param domain {string} Domain scope of the service, typically "local.".
    * @return {Observable<ZeroconfResult>} Returns an Observable that notifies of each service added or removed.
@@ -112,10 +110,6 @@ export class Zeroconf {
 
   /**
    * Stops watching for services of the specified type.
-   * @usage
-   * ```typescript
-   * this.zeroconf.unwatch('_http._tcp.', 'local.');
-   * ```
    * @param type {string} Service type name, e.g. "_http._tcp".
    * @param domain {string} Domain scope of the service, typically "local.".
    * @return {Promise<void>}


### PR DESCRIPTION
This PR adds support for [cordova-plugin-zeroconf](https://github.com/becvert/cordova-plugin-zeroconf), as requested in #636.

Please note that I only tested the browsing/watching functionality, since I've never published a zeroconf service myself (on a mobile device) and I wouldn't really know how to test that.

A note on naming: The plugin uses all lowercase `zeroconf` as pluginRef and in examples, but uses camel-case `ZeroConf` internally and sporadically in the docs. However, the [official zeroconf site](http://www.zeroconf.org/) refers to `Zeroconf` with initial caps only. I decided to go with the latter, even if that may look unfamiliar to some (but hey, so does `Geolocation`). It also avoid naming the package `zero-conf` which isn't used widely, and might cause even more confusion. 
Yes, sometimes I do pay attention to such details ;-)
