### PR TITLE
feat(secure-storage): add keys() and clear() methods

### DIFF
--- a/src/@ionic-native/plugins/secure-storage/index.ts
+++ b/src/@ionic-native/plugins/secure-storage/index.ts
@@ -41,6 +41,26 @@ export class SecureStorageObject {
   })
   remove(reference: string): Promise<any> { return; }
 
+  /**
+   * Get all references from the storage.
+   * @returns {Promise<any>}
+   */
+  @CordovaInstance({
+    callbackOrder: 'reverse'
+  })
+  keys(): Promise<any> { return; }
+
+  /**
+   * Clear all references from the storage.
+   * @returns {Promise<any>}
+   */
+  @CordovaInstance({
+    callbackOrder: 'reverse'
+  })
+  clear(): Promise<any> { return; }
+
+
+
 }
 
 /**


### PR DESCRIPTION
I've added the keys() and clear() methods that are present in later versions of the cordova-secure-storage plugin (from 2.6.0 - 2016-10-26)