### PR TITLE
chore(): use CircleCI 2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,12 +19,12 @@ jobs:
          paths:
          - ~/ionic-site/
       - restore_cache:
-         key: {{ checksum "package.json" }}-node-modules
+         key: node_modules_{{ checksum "package.json" }}
       - run:
          name: Install node modules
          command: npm i
       - save_cache:
-         key: {{ checksum "package.json" }}-node-modules # used cached node_modules if package.json didn't change
+         key: node_modules_{{ checksum "package.json" }} # used cached node_modules if package.json didn't change
          paths:
          - ~/ionic-native/node_modules/
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,6 @@ jobs:
          command: npm i
       - run: npm run build
   update_docs:
-    machine: true
     working_directory: ~/ionic-native/
     docker:
       - image: node:7

--- a/circle.yml
+++ b/circle.yml
@@ -33,9 +33,8 @@ jobs:
       - deploy:
           name: Update docs
           command: |
-            if [ "${CIRCLE_BRANCH}" == "cci2" ]; then
-              # update docs since we're on master
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
               ./scripts/docs/update_docs.sh
             else
-              echo "We are on ${CIRCLE_BRANCH} branch, not going to update docs"
+              echo "We are on ${CIRCLE_BRANCH} branch, not going to update docs."
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ jobs:
       - deploy:
           name: Update docs
           command: |
-            if [ "${CIRCLE_BRANCH}" == "cci2" ]; then
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
               ./scripts/docs/update_docs.sh
             else
               echo "We are on ${CIRCLE_BRANCH} branch, not going to update docs."

--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ jobs:
       - deploy:
           name: Update docs
           command: |
-            if [ "${CIRCLE_BRANCH}" == "cci2" ]; then
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
               ./scripts/docs/update_docs.sh
             else
               echo "We are on ${CIRCLE_BRANCH} branch, not going to update docs."

--- a/circle.yml
+++ b/circle.yml
@@ -26,7 +26,7 @@ jobs:
       - save_cache:
          key: node-modules-{{ checksum "package.json" }} # used cached node_modules if package.json didn't change
          paths:
-         - ~/node_modules/
+         - ~/ionic-native/node_modules/
       - run:
           name: Run tslint
           command: npm run lint

--- a/circle.yml
+++ b/circle.yml
@@ -8,29 +8,17 @@ jobs:
       - only:
         - cci2
     steps:
+      - run:
+            name: Prepare ionic-site repo
+            command: ./scripts/docs/prepare.sh
+      - save_cache:
+               paths:
+                 - ~/ionic-site/
       - checkout
       - run:
          name: Install node modules
          command: npm i
-      - run: npm run build
-  update_docs:
-    working_directory: ~/ionic-native/
-    docker:
-      - image: node:7
-    branches:
-      - only:
-        - cci2 # set this to master
-    steps:
-      - run:
-          name: Prepare ionic-site repo
-          command: ./scripts/docs/prepare.sh
-      - save_cache:
-         paths:
-           - ~/ionic-site/
-      - checkout
-      - run:
-          name: Install node modules
-          command: npm i
+      - run: npm run lint
       - run:
           name: Update docs
           command: ./scripts/docs/update_docs.sh

--- a/circle.yml
+++ b/circle.yml
@@ -30,10 +30,11 @@ jobs:
       - run:
           name: Run tslint
           command: npm run lint
+      - add_ssh_keys
       - deploy:
           name: Update docs
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "cci2" ]; then
               ./scripts/docs/update_docs.sh
             else
               echo "We are on ${CIRCLE_BRANCH} branch, not going to update docs."

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ jobs:
       - checkout
       - run:
          name: Install node modules
-         run: npm i
+         command: npm i
   deployDocs:
     working_directory: ~/ionic-native/
     docker:

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,9 @@ jobs:
       - run:
          name: Install node modules
          command: npm i
-  deployDocs:
+      - run: npm run build
+  update_docs:
+    machine: true
     working_directory: ~/ionic-native/
     docker:
       - image: node:7

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ jobs:
       - only:
         - cci2
     steps:
+      - checkout
       - restore_cache:
          key: ionic-site
       - run:
@@ -17,7 +18,6 @@ jobs:
                key: ionic-site
                paths:
                  - ~/ionic-site/
-      - checkout
       - run:
          name: Install node modules
          command: npm i

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ jobs:
          paths:
          - ~/ionic-site/
       - restore_cache:
-         key: node_modules
+         key: node-modules-{{ checksum "package.json" }}
       - run:
          name: Install node modules
          command: npm i

--- a/circle.yml
+++ b/circle.yml
@@ -24,12 +24,18 @@ jobs:
          name: Install node modules
          command: npm i
       - save_cache:
-         key: node_modules_{{ checksum "package.json" }} # used cached node_modules if package.json didn't change
+         key: node_modules_{{ checksum "package.json" }}
          paths:
          - ~/ionic-native/node_modules/
       - run:
           name: Run tslint
           command: npm run lint
-      - run:
+      - deploy:
           name: Update docs
-          command: ./scripts/docs/update_docs.sh
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "cci2" ]; then
+              # update docs since we're on master
+              ./scripts/docs/update_docs.sh
+            else
+              echo "We are on ${CIRCLE_BRANCH} branch, not going to update docs"
+            fi

--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ jobs:
       - deploy:
           name: Update docs
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "cci2" ]; then
               ./scripts/docs/update_docs.sh
             else
               echo "We are on ${CIRCLE_BRANCH} branch, not going to update docs."

--- a/circle.yml
+++ b/circle.yml
@@ -1,26 +1,35 @@
-machine:
-  node:
-    version: 5.5.0
-  ruby:
-    version: 2.1.2
-
-general:
-  branches:
-    only:
-      - master # ignore PRs and branches
-
-dependencies:
- pre:
-   - ./scripts/docs/prepare.sh
- cache_directories:
-   - "~/ionic-site" # cache ionic-site
-
-test:
-  override:
-    - echo "No tests to run"
-
-deployment:
- staging:
-   branch: master
-   commands:
-     - ./scripts/docs/update_docs.sh
+version: 2
+jobs:
+  build:
+    working_directory: ~/ionic-native/
+    docker:
+      - image: node:7
+    branches:
+      - only:
+        - cci2
+    steps:
+      - checkout
+      - run:
+         name: Install node modules
+         run: npm i
+  deployDocs:
+    working_directory: ~/ionic-native/
+    docker:
+      - image: node:7
+    branches:
+      - only:
+        - cci2 # set this to master
+    steps:
+      - run:
+          name: Prepare ionic-site repo
+          command: ./scripts/docs/prepare.sh
+      - save_cache:
+         paths:
+           - ~/ionic-site/
+      - checkout
+      - run:
+          name: Install node modules
+          command: npm i
+      - run:
+          name: Update docs
+          command: ./scripts/docs/update_docs.sh

--- a/circle.yml
+++ b/circle.yml
@@ -12,16 +12,24 @@ jobs:
       - restore_cache:
          key: ionic-site
       - run:
-            name: Prepare ionic-site repo
-            command: ./scripts/docs/prepare.sh
+         name: Prepare ionic-site repo
+         command: ./scripts/docs/prepare.sh
       - save_cache:
-               key: ionic-site
-               paths:
-                 - ~/ionic-site/
+         key: ionic-site
+         paths:
+         - ~/ionic-site/
+      - restore_cache:
+         key: node_modules
       - run:
          name: Install node modules
          command: npm i
-      - run: npm run lint
+      - save_cache:
+         key: node-modules-{{ checksum "package.json" }} # used cached node_modules if package.json didn't change
+         paths:
+         - ~/node_modules/
+      - run:
+          name: Run tslint
+          command: npm run lint
       - run:
           name: Update docs
           command: ./scripts/docs/update_docs.sh

--- a/circle.yml
+++ b/circle.yml
@@ -19,12 +19,12 @@ jobs:
          paths:
          - ~/ionic-site/
       - restore_cache:
-         key: node-modules-{{ checksum "package.json" }}
+         key: {{ checksum "package.json" }}-node-modules
       - run:
          name: Install node modules
          command: npm i
       - save_cache:
-         key: node-modules-{{ checksum "package.json" }} # used cached node_modules if package.json didn't change
+         key: {{ checksum "package.json" }}-node-modules # used cached node_modules if package.json didn't change
          paths:
          - ~/ionic-native/node_modules/
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -8,10 +8,13 @@ jobs:
       - only:
         - cci2
     steps:
+      - restore_cache:
+         key: ionic-site
       - run:
             name: Prepare ionic-site repo
             command: ./scripts/docs/prepare.sh
       - save_cache:
+               key: ionic-site
                paths:
                  - ~/ionic-site/
       - checkout

--- a/src/@ionic-native/plugins/status-bar/index.ts
+++ b/src/@ionic-native/plugins/status-bar/index.ts
@@ -19,10 +19,11 @@ declare var window;
  *
  * ...
  *
+ * // let status bar overlay webview
+ * this.statusBar.overlaysWebView(true);
  *
- * this.statusBar.overlaysWebView(true); // let status bar overlay webview
- *
- * this.statusBar.backgroundColorByHexString('#ffffff'); // set status bar to white
+ * // set status bar to white
+ * this.statusBar.backgroundColorByHexString('#ffffff');
  * ```
  *
  */


### PR DESCRIPTION
Managed to drop build time to 20 seconds (from 1:45+).

- ionic-site is always cached, the scripts will take care of updating it
- node_modules gets restored from cache unless `package.json` changes (takes 10-20 more seconds to install them from scratch).
- configured it to update docs on master branch, it's a bit hacky now. Their docs say they will have a better way to do it soon

Just need to remove lines 7-9 and it's good to go. (the branches property)