### PR TITLE
Update index.ts

### DIFF
--- a/src/@ionic-native/plugins/admob/index.ts
+++ b/src/@ionic-native/plugins/admob/index.ts
@@ -95,7 +95,7 @@ export interface AdExtras {
  * Plugin for Google Ads, including AdMob / DFP (doubleclick for publisher) and mediations to other Ad networks.
  * @usage
  * ```typescript
- * import { AdMob, AdMobOptions, AdSize, AdExtras } from '@ionic-native/ad-mob';
+ * import { AdMob, AdMobOptions, AdSize, AdExtras } from '@ionic-native/admob';
  *
  * constructor(private admob: AdMob){}
  *


### PR DESCRIPTION
remove the dash "import { AdMob, AdMobOptions, AdSize, AdExtras } from '@ionic-native/ad-mob';" to import { AdMob, AdMobOptions, AdSize, AdExtras } from '@ionic-native/admob' because typescript will not import the specified clases