### PR TITLE
Correct typo on Line 14

### DIFF
--- a/src/@ionic-native/plugins/flashlight/index.ts
+++ b/src/@ionic-native/plugins/flashlight/index.ts
@@ -11,7 +11,7 @@ import { Cordova, Plugin } from '@ionic-native/core';
  * ```typescript
  * import { Flashlight } from '@ionic-native/flashlight';
  *
- * constructor(private flashlight: FlashLight) { }
+ * constructor(private flashlight: Flashlight) { }
  *
  * ...
  *


### PR DESCRIPTION
There is a typo on line 14, changed from
```
 * constructor(private flashlight: FlashLight) { }
```
to
```
 * constructor(private flashlight: Flashlight) { }
```