### PR TITLE
Fix musicControls.subscribe() example code

### DIFF
--- a/src/@ionic-native/plugins/music-controls/index.ts
+++ b/src/@ionic-native/plugins/music-controls/index.ts
@@ -56,7 +56,7 @@ export interface MusicControlsOptions {
  *   ticker    : 'Now playing "Time is Running Out"'
  *  });
  *
- *  this.musicControls.subscribe(action => {
+ *  this.musicControls.subscribe().subscribe(action => {
  *
  *    switch(action) {
  *        case 'music-controls-next':


### PR DESCRIPTION
The sample code does not work...this change returns the observable first with subscribe() before actually calling the Observable's subscribe method.

In fact, the way it's written in the example, the code would not build because of typescript errors.