### PR TITLE
Syntax error in ShareViaEmail: typescript + ionic2

### DIFF
--- a/src/@ionic-native/plugins/social-sharing/index.ts
+++ b/src/@ionic-native/plugins/social-sharing/index.ts
@@ -22,7 +22,7 @@ import { Cordova, Plugin } from '@ionic-native/core';
  * });
  *
  * // Share via email
- * this.socialSharing.shareViaEmail('Body', 'Subject', 'recipient@example.org').then(() => {
+ * this.socialSharing.shareViaEmail('Body', 'Subject', ['recipient@example.org']).then(() => {
  *   // Success!
  * }).catch(() => {
  *   // Error!


### PR DESCRIPTION
ShareViaEmail parameter for providing email "must be null or an array" because it's type is "string:[]" and the provided syntax is wrong, so i have updated that syntax.