### PR TITLE
feat(CameraPreview) : add getSupportedPictureSizes() support

### DIFF
--- a/src/@ionic-native/plugins/camera-preview/index.ts
+++ b/src/@ionic-native/plugins/camera-preview/index.ts
@@ -157,40 +157,28 @@ export class CameraPreview {
    * Stops the camera preview instance. (iOS & Android)
    * @return {Promise<any>}
    */
-  @Cordova({
-    successIndex: 0,
-    errorIndex: 1
-  })
+  @Cordova()
   stopCamera(): Promise<any> { return; }
 
   /**
    * Switch from the rear camera and front camera, if available.
    * @return {Promise<any>}
    */
-  @Cordova({
-    successIndex: 0,
-    errorIndex: 1
-  })
+  @Cordova()
   switchCamera(): Promise<any> { return; }
 
   /**
    * Hide the camera preview box.
    * @return {Promise<any>}
    */
-  @Cordova({
-    successIndex: 0,
-    errorIndex: 1
-  })
+  @Cordova()
   hide(): Promise<any> { return; }
 
   /**
    * Show the camera preview box.
    * @return {Promise<any>}
    */
-  @Cordova({
-    successIndex: 0,
-    errorIndex: 1
-  })
+  @Cordova()
   show(): Promise<any> { return; }
 
   /**
@@ -256,10 +244,7 @@ export class CameraPreview {
    * get supported picture size
    * @return {Promise<any>}
    */
-  @Cordova({
-    successIndex: 0,
-    errorIndex: 1
-  })
+  @Cordova()
   getSupportedPictureSizes(): Promise<any> { return; }
 
 }

--- a/src/@ionic-native/plugins/camera-preview/index.ts
+++ b/src/@ionic-native/plugins/camera-preview/index.ts
@@ -39,12 +39,12 @@ export interface CameraPreviewOptions {
 }
 
 export interface CameraPreviewPictureOptions {
-  /** The width in pixels, default 0 */
-  width?: number;
-  /** The height in pixels, default 0 */
-  height?: number;
-  /** The picture quality, 0 - 100, default 85 */
-  quality?: number;
+    /** The width in pixels, default 0 */
+    width?: number;
+    /** The height in pixels, default 0 */
+    height?: number;
+    /** The picture quality, 0 - 100, default 85 */
+    quality?: number;
 }
 
 /**

--- a/src/@ionic-native/plugins/camera-preview/index.ts
+++ b/src/@ionic-native/plugins/camera-preview/index.ts
@@ -117,6 +117,14 @@ export interface CameraPreviewPictureOptions {
  * // Stop the camera preview
  * this.cameraPreview.stopCamera();
  *
+ *
+ * // Get supported Picture size
+ * this.cameraPreview.getSupportedPictureSizes().then( (dimensions) => {
+ *  dimensions.forEach((dimension) => {
+ *    console.log(dimension.width + " / " + dimension.height)
+ *  })
+ * })
+ *
  * ```
  *
  * @interfaces

--- a/src/@ionic-native/plugins/camera-preview/index.ts
+++ b/src/@ionic-native/plugins/camera-preview/index.ts
@@ -39,12 +39,12 @@ export interface CameraPreviewOptions {
 }
 
 export interface CameraPreviewPictureOptions {
-    /** The width in pixels, default 0 */
-    width?: number;
-    /** The height in pixels, default 0 */
-    height?: number;
-    /** The picture quality, 0 - 100, default 85 */
-    quality?: number;
+  /** The width in pixels, default 0 */
+  width?: number;
+  /** The height in pixels, default 0 */
+  height?: number;
+  /** The picture quality, 0 - 100, default 85 */
+  quality?: number;
 }
 
 /**
@@ -243,5 +243,15 @@ export class CameraPreview {
     errorIndex: 2
   })
   setFlashMode(flashMode?: string): Promise<any> { return; }
+
+  /**
+   * get supported picture size
+   * @return {Promise<any>}
+   */
+  @Cordova({
+    successIndex: 0,
+    errorIndex: 1
+  })
+  getSupportedPictureSizes(): Promise<any> { return; }
 
 }


### PR DESCRIPTION
CameraPreview plugin has getSupportedPictureSizes() method but ionic-native hasn't this.

I tested this on:
* iPad gen4
* SOL22(Sony XPERIA android4.2.2)
