### PR TITLE
Minor documentation fix

### DIFF
--- a/src/@ionic-native/plugins/media/index.ts
+++ b/src/@ionic-native/plugins/media/index.ts
@@ -160,9 +160,8 @@ export class MediaObject {
  *      });
  *
  *      // get file duration
- *      file.getDuration().then((duration) => {
- *         console.log(position);
- *      });
+ *      let duration = file.getDuration();
+ *      console.log(duration);
  *
  *      // skip to 10 seconds (expects int value in ms)
  *      file.seekTo(10000);


### PR DESCRIPTION
`getDuration` is synchronous, inside the example it was used with a promise, which is quite missleading...