### PR TITLE
The 'options' parameter is currently required

### DIFF
--- a/src/@ionic-native/plugins/google-plus/index.ts
+++ b/src/@ionic-native/plugins/google-plus/index.ts
@@ -12,7 +12,7 @@ import { Cordova, Plugin } from '@ionic-native/core';
  *
  * ...
  *
- * this.googlePlus.login()
+ * this.googlePlus.login({})
  *   .then(res => console.log(res))
  *   .catch(err => console.error(err));
  *


### PR DESCRIPTION
Issue reported: https://forum.ionicframework.com/t/ionic-native-googleplus-unrecognized-selector-sent-to-instance/81944/3

In order to correctly call the login method on the GooglePlus provider you need to pass it the 'options' parameter even if it's empty.