### PR TITLE
Update secure storage plugin documentation to reflect the correct order for key:value pairs.

### DIFF
--- a/src/@ionic-native/plugins/secure-storage/index.ts
+++ b/src/@ionic-native/plugins/secure-storage/index.ts
@@ -86,7 +86,7 @@ export class SecureStorageObject {
  *          error => console.log(error)
  *      );
  *
- *      storage.set('myitem', 'myvalue')
+ *      storage.set('myvalue', 'myitem')
  *        .then(
  *         data => console.log(data),
  *          error => console.log(error)


### PR DESCRIPTION
The order of the key value pair arguments were incorrect.