### PR TITLE
change executeSql doc to mention create instead of openDatabase

### DIFF
--- a/src/@ionic-native/plugins/sqlite/index.ts
+++ b/src/@ionic-native/plugins/sqlite/index.ts
@@ -67,7 +67,7 @@ export class SQLiteObject {
   start(): void { }
 
   /**
-   * Execute SQL on the opened database. Note, you must call `openDatabase` first, and
+   * Execute SQL on the opened database. Note, you must call `create` first, and
    * ensure it resolved and successfully opened the database.
    */
   @CordovaInstance()


### PR DESCRIPTION
The documentation for SQLite's `executeSql` method mentions that users must have previously called `openDatabase`, which I believe has been renamed/subsumed by the `create` method, so this PR adjusts the comment accordingly.