### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Native plugin wrappers for Cordova and Ionic with TypeScript, ES6+, Promise and Observable support",
   "license": "MIT",
   "devDependencies": {
-    "@angular/compiler": "2.4.8",
-    "@angular/compiler-cli": "2.4.8",
-    "@angular/core": "2.4.8",
+    "@angular/compiler": "4.0.0",
+    "@angular/compiler-cli": "4.0.0",
+    "@angular/core": "4.0.0",
     "canonical-path": "0.0.2",
     "child-process-promise": "2.2.0",
     "conventional-changelog-cli": "1.2.0",
@@ -27,12 +27,12 @@
     "q": "1.4.1",
     "queue": "4.2.1",
     "rimraf": "2.5.4",
-    "rxjs": "5.0.1",
+    "rxjs": "5.1.1",
     "semver": "5.3.0",
     "tslint": "3.15.1",
     "tslint-ionic-rules": "0.0.7",
-    "typescript": "2.0.09",
-    "zone.js": "0.7.2"
+    "typescript": "2.2.1",
+    "zone.js": "^0.8.4"
   },
   "scripts": {
     "start": "npm run test:watch",


### PR DESCRIPTION
When users installing a v3 package they will always receive this error

```
PS C:\Users\xxx\Documents\Projekte\xxx> npm install --save @ionic-native/app-rate
ionic-hello-world@ C:\Users\xxx\Documents\Projekte\xxx
+-- UNMET PEER DEPENDENCY @angular/core@4.0.0
`-- @ionic-native/app-rate@3.4.4
```

Since Ionic 3.0 released, the package should be able to support Angular 4.0.0.
I updated the dependencies for that.