### PR TITLE
Type result of barcode scan

### DIFF
--- a/src/@ionic-native/plugins/barcode-scanner/index.ts
+++ b/src/@ionic-native/plugins/barcode-scanner/index.ts
@@ -56,6 +56,12 @@ export interface BarcodeScannerOptions {
 
 }
 
+export interface BarcodeScanResult {
+  format: "QR_CODE" | "DATA_MATRIX" | "UPC_E" | "UPC_A" | "EAN_8" | "EAN_13" | "CODE_128" | "CODE_39" | "CODE_93" | "CODABAR" | "ITF" | "RSS14" | "RSS_EXPANDED" | "PDF417" | "AZTEC" | "MSI";
+  cancelled: boolean;
+  text: string;
+}
+
 /**
  * @name Barcode Scanner
  * @description
@@ -80,6 +86,7 @@ export interface BarcodeScannerOptions {
  * ```
  * @interfaces
  * BarcodeScannerOptions
+ * BarcodeScanResult
  */
 @Plugin({
   pluginName: 'BarcodeScanner',
@@ -111,7 +118,7 @@ export class BarcodeScanner extends IonicNativePlugin {
   @Cordova({
     callbackOrder: 'reverse'
   })
-  scan(options?: BarcodeScannerOptions): Promise<any> { return; }
+  scan(options?: BarcodeScannerOptions): Promise<BarcodeScanResult> { return; }
 
   /**
    * Encodes data into a barcode.


### PR DESCRIPTION
Make an interface type for the result of barcode scanning, so it can return something more strongly typed than `Promise<any>`.