### PR TITLE
docs(printer): Fix example

### DIFF
--- a/src/@ionic-native/plugins/printer/index.ts
+++ b/src/@ionic-native/plugins/printer/index.ts
@@ -62,7 +62,7 @@ export interface PrintOptions {
  *      grayscale: true
  *    };
  *
- * this.p.print(content, options).then(onSuccess, onError);
+ * this.printer.print(content, options).then(onSuccess, onError);
  * ```
  * @interfaces
  * PrintOptions


### PR DESCRIPTION
`this.p` is not defined as Printer is imported as `printer`