### PR TITLE
(CameraPreview) New focus methods & getFlashMode()

### DIFF
--- a/src/@ionic-native/plugins/camera-preview/index.ts
+++ b/src/@ionic-native/plugins/camera-preview/index.ts
@@ -134,7 +134,18 @@ export interface CameraPreviewPictureOptions {
 @Injectable()
 export class CameraPreview {
 
-  EXPOSURE_MODES = {
+  FOCUS_MODE = {
+    FIXED: 'fixed',
+    AUTO: 'auto',
+    CONTINUOUS: 'continuous', // IOS Only
+    CONTINUOUS_PICTURE: 'continuous-picture', // Android Only
+    CONTINUOUS_VIDEO: 'continuous-video', // Android Only
+    EDOF: 'edof', // Android Only
+    INFINITY: 'infinity', // Android Only
+    MACRO: 'macro' // Android Only
+  };
+
+  EXPOSURE_MODE = {
     LOCK: 'lock', // IOS Only
     AUTO: 'auto', // IOS Only
     CONTINUOUS: 'continuous',
@@ -266,6 +277,38 @@ export class CameraPreview {
   setPreviewSize(dimensions?: CameraPreviewDimensions): Promise<any> { return; }
 
   /**
+   * Get focus mode
+   * @return {Promise<any>}
+   */
+  @Cordova()
+  getFocusMode(): Promise<any> { return; }
+
+  /**
+   * Set the focus mode
+   * @param [focusMode] {string} 'fixed', 'auto', 'continuous-picture', 'continuous-video' (iOS & Android), 'edof', 'infinity', 'macro' (Android Only)
+   * @return {Promise<any>}
+   */
+  @Cordova({
+    successIndex: 1,
+    errorIndex: 2
+  })
+  setFocusMode(focusMode?: string): Promise<any> { return; }
+
+  /**
+   * Get supported focus modes
+   * @return {Promise<any>}
+   */
+  @Cordova()
+  getSupportedFocusModes(): Promise<any> { return; }
+
+  /**
+   * Get the current flash mode
+   * @return {Promise<any>}
+   */
+  @Cordova()
+  getFlashMode(): Promise<any> { return; }
+
+  /**
    * Set the flashmode
    * @param [flashMode] {string} 'off' (iOS & Android), 'on' (iOS & Android), 'auto' (iOS & Android), 'torch' (Android)
    * @return {Promise<any>}
@@ -277,18 +320,18 @@ export class CameraPreview {
   setFlashMode(flashMode?: string): Promise<any> { return; }
 
   /**
-   * Get supported picture sizes
-   * @return {Promise<any>}
-   */
-  @Cordova()
-  getSupportedPictureSizes(): Promise<any> { return; }
-
-  /**
    * Get supported flash modes
    * @return {Promise<any>}
    */
   @Cordova()
   getSupportedFlashModes(): Promise<any> { return; }
+
+  /**
+   * Get supported picture sizes
+   * @return {Promise<any>}
+   */
+  @Cordova()
+  getSupportedPictureSizes(): Promise<any> { return; }
 
   /**
    * Get exposure mode


### PR DESCRIPTION
4 new methods are available in the master:
- getSupportedFocusModes();
- getFocusMode();
- seFocusMode();
- getFlashMode();

1 mistake correction for the FLASH_MODE type

Thanks in advance for the update
