### PR TITLE
chore(rxjs): fix problems with Ionic Cloud

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "dependencies": {
-    "rxjs": "5.0.0-beta.12"
+    "rxjs": "5.1.1"
   },
   "devDependencies": {
     "browserify": "^13.3.0",


### PR DESCRIPTION
Some users reported problems with Ionic Native because the rxjs dependency is too old.
I upüdated rxjs to match ionic-angular and ionic-cloud

Issue: https://github.com/driftyco/ionic-cloud/issues/190