### PR TITLE
typo(docs):  Unified the documentations

### DIFF
--- a/src/@ionic-native/core/decorators.ts
+++ b/src/@ionic-native/core/decorators.ts
@@ -127,10 +127,10 @@ export function InstanceCheck(opts: CordovaCheckOptions = {}) {
           if (opts.sync) {
             return;
           } else if (opts.observable) {
-            return new Observable<any>(() => {});
+            return new Observable<any>(() => { });
           }
 
-          return getPromise(() => {});
+          return getPromise(() => { });
 
         }
       }
@@ -290,10 +290,10 @@ export function CordovaProperty(target: any, key: string) {
 export function InstanceProperty(target: any, key: string) {
   Object.defineProperty(target, key, {
     enumerable: true,
-    get: function(){
+    get: function() {
       return this._objectInstance[key];
     },
-    set: function(value){
+    set: function(value) {
       this._objectInstance[key] = value;
     }
   });

--- a/src/@ionic-native/core/ionic-native-plugin.ts
+++ b/src/@ionic-native/core/ionic-native-plugin.ts
@@ -21,7 +21,7 @@ export class IonicNativePlugin {
   /**
    * Returns the original plugin object
    */
-  static getPlugin(): any {}
+  static getPlugin(): any { }
 
   /**
    * Returns the plugin's name

--- a/src/@ionic-native/core/plugin.ts
+++ b/src/@ionic-native/core/plugin.ts
@@ -150,7 +150,7 @@ function wrapPromise(pluginObj: any, methodName: string, args: any[], opts: any 
   return p;
 }
 
-function wrapOtherPromise(pluginObj: any, methodName: string, args: any[], opts: any= {}) {
+function wrapOtherPromise(pluginObj: any, methodName: string, args: any[], opts: any = {}) {
   return getPromise((resolve, reject) => {
     const pluginResult = callCordovaPlugin(pluginObj, methodName, args, opts);
     if (pluginResult) {
@@ -225,7 +225,7 @@ export function overrideFunction(pluginObj: any, methodName: string, args: any[]
     if (availabilityCheck === true) {
       const pluginInstance = getPlugin(pluginObj.constructor.getPluginRef());
       pluginInstance[methodName] = observer.next.bind(observer);
-      return () => pluginInstance[methodName] = () => {};
+      return () => pluginInstance[methodName] = () => { };
     } else {
       observer.error(availabilityCheck);
       observer.complete();

--- a/src/@ionic-native/plugins/admob-free/index.ts
+++ b/src/@ionic-native/plugins/admob-free/index.ts
@@ -69,7 +69,7 @@ export interface AdMobFreeRewardVideoConfig {
  * @description
  *
  * @usage
- * ```
+ * ```typescript
  * import { AdMobFree, AdMobFreeBannerConfig } from '@ionic-native/admob-free';
  *
  *

--- a/src/@ionic-native/plugins/alipay/index.ts
+++ b/src/@ionic-native/plugins/alipay/index.ts
@@ -67,7 +67,7 @@ export interface AlipayOrder {
  * Requires Cordova plugin: `cordova-alipay-base`. For more info, please see the [Alipay plugin docs](https://github.com/xueron/cordova-alipay-base).
  *
  * @usage
- * ```
+ * ```typescript
  * import { Alipay, AlipayOrder } from '@ionic-native/alipay';
  *
  * constructor(private alipay: Alipay) {
@@ -112,4 +112,3 @@ export class Alipay extends IonicNativePlugin {
   @Cordova()
   pay(order: AlipayOrder): Promise<any> { return; }
 }
-

--- a/src/@ionic-native/plugins/android-fingerprint-auth/index.ts
+++ b/src/@ionic-native/plugins/android-fingerprint-auth/index.ts
@@ -114,18 +114,18 @@ export interface AFAEncryptResponse {
  *     if(result.isAvailable){
  *       // it is available
  *
- *       this.androidFingerprintAuth.encrypt({ clientId: "myAppName", username: "myUsername", password: "myPassword" })
+ *       this.androidFingerprintAuth.encrypt({ clientId: 'myAppName', username: 'myUsername', password: 'myPassword' })
  *         .then(result => {
  *            if (result.withFingerprint) {
- *                console.log("Successfully encrypted credentials.");
- *                console.log("Encrypted credentials: " + result.token);
+ *                console.log('Successfully encrypted credentials.');
+ *                console.log('Encrypted credentials: ' + result.token);
  *            } else if (result.withBackup) {
  *              console.log('Successfully authenticated with backup password!');
  *            } else console.log('Didn\'t authenticate!');
  *         })
  *         .catch(error => {
- *            if (error === "Cancelled") {
- *              console.log("Fingerprint authentication cancelled");
+ *            if (error === 'Cancelled') {
+ *              console.log('Fingerprint authentication cancelled');
  *            } else console.error(error)
  *         });
  *
@@ -156,7 +156,7 @@ export class AndroidFingerprintAuth extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  encrypt(options: AFAAuthOptions): Promise<AFAEncryptResponse> {return; }
+  encrypt(options: AFAAuthOptions): Promise<AFAEncryptResponse> { return; }
 
   /**
    * Opens a native dialog fragment to use the device hardware fingerprint scanner to authenticate against fingerprints registered for the device.
@@ -164,19 +164,19 @@ export class AndroidFingerprintAuth extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  decrypt(options: AFAAuthOptions): Promise<AFADecryptOptions> {return; }
+  decrypt(options: AFAAuthOptions): Promise<AFADecryptOptions> { return; }
 
   /**
    * Check if service is available
    * @returns {Promise<any>} Returns a Promise that resolves if fingerprint auth is available on the device
    */
   @Cordova()
-  isAvailable(): Promise<{isAvailable: boolean}> { return; }
+  isAvailable(): Promise<{ isAvailable: boolean }> { return; }
 
   /**
    * Delete the cipher used for encryption and decryption by username
    * @returns {Promise<any>} Returns a Promise that resolves if the cipher was successfully deleted
    */
   @Cordova()
-  delete(options: {clientId: string; username: string; }): Promise<{deleted: boolean}> { return; }
+  delete(options: { clientId: string; username: string; }): Promise<{ deleted: boolean }> { return; }
 }

--- a/src/@ionic-native/plugins/app-update/index.ts
+++ b/src/@ionic-native/plugins/app-update/index.ts
@@ -19,7 +19,7 @@ import { Injectable } from '@angular/core';
  *
  * Then use the following code:
  *
- * ```
+ * ```typescript
  * import { AppUpdate } from '@ionic-native/app-update';
  *
  * constructor(private appUpdate: AppUpdate) {
@@ -28,8 +28,6 @@ import { Injectable } from '@angular/core';
  *    this.appUpdate.checkAppUpdate(updateUrl);
  *
  * }
- *
- *
  * ```
  *
  * The plugin will compare the app version and update it automatically if the API has a newer version to install.
@@ -53,4 +51,3 @@ export class AppUpdate extends IonicNativePlugin {
   })
   checkAppUpdate(updateUrl: string): Promise<any> { return; }
 }
-

--- a/src/@ionic-native/plugins/appodeal/index.ts
+++ b/src/@ionic-native/plugins/appodeal/index.ts
@@ -8,7 +8,7 @@ import { Injectable } from '@angular/core';
  * Plugin to serve ads through native Appodeal SDKs
  *
  * @usage
- * ```
+ * ```typescript
  * import { Appodeal } from '@ionic-native/appodeal';
  *
  * constructor(private appodeal: Appodeal) {
@@ -18,9 +18,6 @@ import { Injectable } from '@angular/core';
  *    appodeal.show(appodeal.AD_TYPES.REWARDED_VIDEO);
  *
  * }
- *
- *
- *
  * ```
  */
 @Plugin({
@@ -28,7 +25,7 @@ import { Injectable } from '@angular/core';
   plugin: 'https://github.com/appodeal/appodeal-cordova-plugin',
   pluginRef: 'Appodeal',
   repo: 'https://github.com/appodeal/appodeal-cordova-plugin.git',
-  platforms: [ 'iOS', 'Android' ]
+  platforms: ['iOS', 'Android']
 })
 @Injectable()
 export class Appodeal extends IonicNativePlugin {
@@ -49,7 +46,7 @@ export class Appodeal extends IonicNativePlugin {
    * @param {number} adType
    */
   @Cordova()
-  initialize(appKey: string, adType: number): void {};
+  initialize(appKey: string, adType: number): void { };
 
   /**
    * check if SDK has been initialized
@@ -76,21 +73,21 @@ export class Appodeal extends IonicNativePlugin {
   showWithPlacement(
     adType: number,
     placement: any
-  ): Promise<any> { return; };
+    ): Promise<any> { return; };
 
   /**
    * hide ad of specified type
    * @param {number} adType
    */
   @Cordova()
-  hide(adType: number): void {};
+  hide(adType: number): void { };
 
   /**
    * confirm use of ads of specified type
    * @param {number} adType
    */
   @Cordova()
-  confirm(adType: number): void {};
+  confirm(adType: number): void { };
 
   /**
    * check if ad of specified type has been loaded
@@ -114,69 +111,69 @@ export class Appodeal extends IonicNativePlugin {
    * @param autoCache
    */
   @Cordova()
-  setAutoCache(adType: number, autoCache: any): void {};
+  setAutoCache(adType: number, autoCache: any): void { };
 
   /**
    * forcefully cache an ad by type
    * @param {number} adType
    */
   @Cordova()
-  cache(adType: number): void {};
+  cache(adType: number): void { };
 
   /**
    *
    * @param {boolean} set
    */
   @Cordova()
-  setOnLoadedTriggerBoth(set: boolean): void {};
+  setOnLoadedTriggerBoth(set: boolean): void { };
 
   /**
    * enable or disable Smart Banners
    * @param {boolean} enabled
    */
   @Cordova()
-  setSmartBanners(enabled: boolean): void {};
+  setSmartBanners(enabled: boolean): void { };
 
   /**
    * enable or disable banner backgrounds
    * @param {boolean} enabled
    */
   @Cordova()
-  setBannerBackground(enabled: boolean): void {};
+  setBannerBackground(enabled: boolean): void { };
 
   /**
    * enable or disable banner animations
    * @param {boolean} enabled
    */
   @Cordova()
-  setBannerAnimation(enabled: boolean): void {};
+  setBannerAnimation(enabled: boolean): void { };
 
   /**
    *
    * @param value
    */
   @Cordova()
-  set728x90Banners(value: any): void {};
+  set728x90Banners(value: any): void { };
 
   /**
    * enable or disable logging
    * @param {boolean} logging
    */
   @Cordova()
-  setLogging(logging: boolean): void {};
+  setLogging(logging: boolean): void { };
 
   /**
    * enable or disable testing mode
    * @param {boolean} testing
    */
   @Cordova()
-  setTesting(testing: boolean): void {};
+  setTesting(testing: boolean): void { };
 
   /**
    * reset device ID
    */
   @Cordova()
-  resetUUID(): void {};
+  resetUUID(): void { };
 
   /**
    * get version of Appdeal SDK
@@ -190,7 +187,7 @@ export class Appodeal extends IonicNativePlugin {
    * @param {number} adType
    */
   @Cordova()
-  disableNetwork(network?: string, adType?: number): void {};
+  disableNetwork(network?: string, adType?: number): void { };
 
   /**
    *
@@ -198,54 +195,54 @@ export class Appodeal extends IonicNativePlugin {
    * @param {number} adType
    */
   @Cordova()
-  disableNetworkType(network?: string, adType?: number): void {};
+  disableNetworkType(network?: string, adType?: number): void { };
 
   /**
    * disable Location permissions for Appodeal SDK
    */
   @Cordova()
-  disableLocationPermissionCheck(): void {};
+  disableLocationPermissionCheck(): void { };
 
   /**
    * disable Storage permissions for Appodeal SDK
    */
   @Cordova()
-  disableWriteExternalStoragePermissionCheck(): void {};
+  disableWriteExternalStoragePermissionCheck(): void { };
 
   /**
    * enable event listeners
    * @param {boolean} enabled
    */
   @Cordova()
-  enableInterstitialCallbacks(enabled: boolean): void {};
+  enableInterstitialCallbacks(enabled: boolean): void { };
 
   /**
    * enable event listeners
    * @param {boolean} enabled
    */
   @Cordova()
-  enableSkippableVideoCallbacks(enabled: boolean): void {};
+  enableSkippableVideoCallbacks(enabled: boolean): void { };
 
   /**
    * enable event listeners
    * @param {boolean} enabled
    */
   @Cordova()
-  enableNonSkippableVideoCallbacks(enabled: boolean): void {};
+  enableNonSkippableVideoCallbacks(enabled: boolean): void { };
 
   /**
    * enable event listeners
    * @param {boolean} enabled
    */
   @Cordova()
-  enableBannerCallbacks(enabled: boolean): void {};
+  enableBannerCallbacks(enabled: boolean): void { };
 
   /**
    * enable event listeners
    * @param {boolean} enabled
    */
   @Cordova()
-  enableRewardedVideoCallbacks(enabled: boolean): void {};
+  enableRewardedVideoCallbacks(enabled: boolean): void { };
 
   /**
    *
@@ -253,7 +250,7 @@ export class Appodeal extends IonicNativePlugin {
    * @param {boolean} value
    */
   @Cordova()
-  setCustomBooleanRule(name: string, value: boolean): void {};
+  setCustomBooleanRule(name: string, value: boolean): void { };
 
   /**
    *
@@ -261,7 +258,7 @@ export class Appodeal extends IonicNativePlugin {
    * @param {number} value
    */
   @Cordova()
-  setCustomIntegerRule(name: string, value: number): void {};
+  setCustomIntegerRule(name: string, value: number): void { };
 
   /**
    * set rule with float value
@@ -269,7 +266,7 @@ export class Appodeal extends IonicNativePlugin {
    * @param {number} value
    */
   @Cordova()
-  setCustomDoubleRule(name: string, value: number): void {};
+  setCustomDoubleRule(name: string, value: number): void { };
 
   /**
    * set rule with string value
@@ -277,77 +274,77 @@ export class Appodeal extends IonicNativePlugin {
    * @param {string} value
    */
   @Cordova()
-  setCustomStringRule(name: string, value: string): void {};
+  setCustomStringRule(name: string, value: string): void { };
 
   /**
    * set ID preference in Appodeal for current user
    * @param id
    */
   @Cordova()
-  setUserId(id: any): void {};
+  setUserId(id: any): void { };
 
   /**
    * set Email preference in Appodeal for current user
    * @param email
    */
   @Cordova()
-  setEmail(email: any): void {};
+  setEmail(email: any): void { };
 
   /**
    * set Birthday preference in Appodeal for current user
    * @param birthday
    */
   @Cordova()
-  setBirthday(birthday: any): void {};
+  setBirthday(birthday: any): void { };
 
   /**
    * et Age preference in Appodeal for current user
    * @param age
    */
   @Cordova()
-  setAge(age: any): void {};
+  setAge(age: any): void { };
 
   /**
    * set Gender preference in Appodeal for current user
    * @param gender
    */
   @Cordova()
-  setGender(gender: any): void {};
+  setGender(gender: any): void { };
 
   /**
    * set Occupation preference in Appodeal for current user
    * @param occupation
    */
   @Cordova()
-  setOccupation(occupation: any): void {};
+  setOccupation(occupation: any): void { };
 
   /**
    * set Relation preference in Appodeal for current user
    * @param relation
    */
   @Cordova()
-  setRelation(relation: any): void {};
+  setRelation(relation: any): void { };
 
   /**
    * set Smoking preference in Appodeal for current user
    * @param smoking
    */
   @Cordova()
-  setSmoking(smoking: any): void {};
+  setSmoking(smoking: any): void { };
 
   /**
    * set Alcohol preference in Appodeal for current user
    * @param alcohol
    */
   @Cordova()
-  setAlcohol(alcohol: any): void {};
+  setAlcohol(alcohol: any): void { };
 
   /**
    * set Interests preference in Appodeal for current user
    * @param interests
    */
   @Cordova()
-  setInterests(interests: any): void {};
+  setInterests(interests: any): void { };
 
   @Cordova({
     eventObservable: true,

--- a/src/@ionic-native/plugins/background-geolocation/index.ts
+++ b/src/@ionic-native/plugins/background-geolocation/index.ts
@@ -448,13 +448,13 @@ export class BackgroundGeolocation extends IonicNativePlugin {
   /**
    * Display app settings to change permissions
    */
-  @Cordova({sync: true})
+  @Cordova({ sync: true })
   showAppSettings(): void { }
 
   /**
    * Display device location settings
    */
-  @Cordova({sync: true})
+  @Cordova({ sync: true })
   showLocationSettings(): void { }
 
   /**

--- a/src/@ionic-native/plugins/background-mode/index.ts
+++ b/src/@ionic-native/plugins/background-mode/index.ts
@@ -148,7 +148,7 @@ export class BackgroundMode extends IonicNativePlugin {
     platforms: ['Android'],
     sync: true
   })
-  moveToBackground(): void {}
+  moveToBackground(): void { }
 
   /**
    * Android allows to programmatically move from background to foreground.
@@ -157,7 +157,7 @@ export class BackgroundMode extends IonicNativePlugin {
     platforms: ['Android'],
     sync: true
   })
-  moveToForeground(): void {}
+  moveToForeground(): void { }
 
   /**
    * Override the back button on Android to go to background instead of closing the app.
@@ -166,7 +166,7 @@ export class BackgroundMode extends IonicNativePlugin {
     platforms: ['Android'],
     sync: true
   })
-  overrideBackButton(): void {}
+  overrideBackButton(): void { }
 
   /**
    * Exclude the app from the recent task list works on Android 5.0+.
@@ -175,7 +175,7 @@ export class BackgroundMode extends IonicNativePlugin {
     platforms: ['Android'],
     sync: true
   })
-  excludeFromTaskList(): void {}
+  excludeFromTaskList(): void { }
 
   /**
    * The method works async instead of isActive() or isEnabled().
@@ -192,7 +192,7 @@ export class BackgroundMode extends IonicNativePlugin {
     platforms: ['Android'],
     sync: true
   })
-  wakeUp(): void {}
+  wakeUp(): void { }
 
   /**
    * Turn screen on and show app even locked
@@ -201,6 +201,6 @@ export class BackgroundMode extends IonicNativePlugin {
     platforms: ['Android'],
     sync: true
   })
-  unlock(): void {}
+  unlock(): void { }
 
 }

--- a/src/@ionic-native/plugins/backlight/index.ts
+++ b/src/@ionic-native/plugins/backlight/index.ts
@@ -9,7 +9,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * This plugin adds turning on/off the device backlight.
  *
  * @usage
- * ```
+ * ```typescript
  * import { Backlight } from '@ionic-native/backlight';
  *
  * constructor(private backlight: Backlight) { }

--- a/src/@ionic-native/plugins/barcode-scanner/index.ts
+++ b/src/@ionic-native/plugins/barcode-scanner/index.ts
@@ -57,7 +57,7 @@ export interface BarcodeScannerOptions {
 }
 
 export interface BarcodeScanResult {
-  format: "QR_CODE" | "DATA_MATRIX" | "UPC_E" | "UPC_A" | "EAN_8" | "EAN_13" | "CODE_128" | "CODE_39" | "CODE_93" | "CODABAR" | "ITF" | "RSS14" | "RSS_EXPANDED" | "PDF417" | "AZTEC" | "MSI";
+  format: 'QR_CODE' | 'DATA_MATRIX' | 'UPC_E' | 'UPC_A' | 'EAN_8' | 'EAN_13' | 'CODE_128' | 'CODE_39' | 'CODE_93' | 'CODABAR' | 'ITF' | 'RSS14' | 'RSS_EXPANDED' | 'PDF417' | 'AZTEC' | 'MSI';
   cancelled: boolean;
   text: string;
 }

--- a/src/@ionic-native/plugins/base64-to-gallery/index.ts
+++ b/src/@ionic-native/plugins/base64-to-gallery/index.ts
@@ -40,7 +40,7 @@ export class Base64ToGallery extends IonicNativePlugin {
     successIndex: 2,
     errorIndex: 3
   })
-  base64ToGallery(data: string, options?: {prefix?: string; mediaScanner?: boolean}): Promise<any> {
+  base64ToGallery(data: string, options?: { prefix?: string; mediaScanner?: boolean }): Promise<any> {
     return;
   }
 

--- a/src/@ionic-native/plugins/ble/index.ts
+++ b/src/@ionic-native/plugins/ble/index.ts
@@ -35,59 +35,59 @@ import { Observable } from 'rxjs/Observable';
  *
  * ```typescript
  *   {
- *       "name": "Battery Demo",
- *       "id": "20:FF:D0:FF:D1:C0",
- *       "advertising": [2,1,6,3,3,15,24,8,9,66,97,116,116,101,114,121],
- *       "rssi": -55
+ *       'name': 'Battery Demo',
+ *       'id': '20:FF:D0:FF:D1:C0',
+ *       'advertising': [2,1,6,3,3,15,24,8,9,66,97,116,116,101,114,121],
+ *       'rssi': -55
  *   }
  * ```
  * After connecting, the peripheral object also includes service, characteristic and descriptor information.
  *
  * ```typescript
  *   {
- *       "name": "Battery Demo",
- *       "id": "20:FF:D0:FF:D1:C0",
- *       "advertising": [2,1,6,3,3,15,24,8,9,66,97,116,116,101,114,121],
- *       "rssi": -55,
- *       "services": [
- *           "1800",
- *           "1801",
- *           "180f"
+ *       'name': 'Battery Demo',
+ *       'id': '20:FF:D0:FF:D1:C0',
+ *       'advertising': [2,1,6,3,3,15,24,8,9,66,97,116,116,101,114,121],
+ *       'rssi': -55,
+ *       'services': [
+ *           '1800',
+ *           '1801',
+ *           '180f'
  *       ],
- *       "characteristics": [
+ *       'characteristics': [
  *           {
- *               "service": "1800",
- *               "characteristic": "2a00",
- *               "properties": [
- *                   "Read"
+ *               'service': '1800',
+ *               'characteristic': '2a00',
+ *               'properties': [
+ *                   'Read'
  *               ]
  *           },
  *           {
- *               "service": "1800",
- *               "characteristic": "2a01",
- *               "properties": [
- *                   "Read"
+ *               'service': '1800',
+ *               'characteristic': '2a01',
+ *               'properties': [
+ *                   'Read'
  *               ]
  *           },
  *           {
- *               "service": "1801",
- *               "characteristic": "2a05",
- *               "properties": [
- *                   "Read"
+ *               'service': '1801',
+ *               'characteristic': '2a05',
+ *               'properties': [
+ *                   'Read'
  *               ]
  *           },
  *           {
- *               "service": "180f",
- *               "characteristic": "2a19",
- *               "properties": [
- *                   "Read"
+ *               'service': '180f',
+ *               'characteristic': '2a19',
+ *               'properties': [
+ *                   'Read'
  *               ],
- *               "descriptors": [
+ *               'descriptors': [
  *                   {
- *                       "uuid": "2901"
+ *                       'uuid': '2901'
  *                   },
  *                   {
- *                       "uuid": "2904"
+ *                       'uuid': '2904'
  *                   }
  *               ]
  *           }
@@ -104,10 +104,10 @@ import { Observable } from 'rxjs/Observable';
  *
  * ```typescript
  *   {
- *       "name": "demo",
- *       "id": "00:1A:7D:DA:71:13",
- *       "advertising": ArrayBuffer,
- *      "rssi": -37
+ *       'name': 'demo',
+ *       'id': '00:1A:7D:DA:71:13',
+ *       'advertising': ArrayBuffer,
+ *      'rssi': -37
  *  }
  * ```
  *
@@ -119,24 +119,24 @@ import { Observable } from 'rxjs/Observable';
  *
  * ```typescript
  *   {
- *       "name": "demo",
- *       "id": "D8479A4F-7517-BCD3-91B5-3302B2F81802",
- *       "advertising": {
- *           "kCBAdvDataChannel": 37,
- *           "kCBAdvDataServiceData": {
- *               "FED8": {
- *                   "byteLength": 7 // data not shown
+ *       'name': 'demo',
+ *       'id': 'D8479A4F-7517-BCD3-91B5-3302B2F81802',
+ *       'advertising': {
+ *           'kCBAdvDataChannel': 37,
+ *           'kCBAdvDataServiceData': {
+ *               'FED8': {
+ *                   'byteLength': 7 // data not shown
  *               }
  *           },
- *           "kCBAdvDataLocalName": "demo",
- *           "kCBAdvDataServiceUUIDs": ["FED8"],
- *           "kCBAdvDataManufacturerData": {
- *               "byteLength": 7  // data not shown
+ *           'kCBAdvDataLocalName': 'demo',
+ *           'kCBAdvDataServiceUUIDs': ['FED8'],
+ *           'kCBAdvDataManufacturerData': {
+ *               'byteLength': 7  // data not shown
  *           },
- *           "kCBAdvDataTxPowerLevel": 32,
- *           "kCBAdvDataIsConnectable": true
+ *           'kCBAdvDataTxPowerLevel': 32,
+ *           'kCBAdvDataIsConnectable': true
  *       },
- *       "rssi": -53
+ *       'rssi': -53
  *   }
  * ```
  *
@@ -230,7 +230,7 @@ export class BLE extends IonicNativePlugin {
     clearFunction: 'stopScan',
     clearWithArgs: false
   })
-  startScanWithOptions(services: string[], options: {reportDuplicates?: boolean} | any): Observable<any> { return; }
+  startScanWithOptions(services: string[], options: { reportDuplicates?: boolean } | any): Observable<any> { return; }
 
   /**
    * Stop a scan started by `startScan`.
@@ -306,14 +306,14 @@ export class BLE extends IonicNativePlugin {
    * // send 1 byte to switch a light on
    * var data = new Uint8Array(1);
    * data[0] = 1;
-   * BLE.write(device_id, "FF10", "FF11", data.buffer);
+   * BLE.write(device_id, 'FF10', 'FF11', data.buffer);
    *
    * // send a 3 byte value with RGB color
    * var data = new Uint8Array(3);
    * data[0] = 0xFF;  // red
    * data[0] = 0x00; // green
    * data[0] = 0xFF; // blue
-   * BLE.write(device_id, "ccc0", "ccc1", data.buffer);
+   * BLE.write(device_id, 'ccc0', 'ccc1', data.buffer);
    *
    * // send a 32 bit integer
    * var data = new Uint32Array(1);
@@ -357,7 +357,7 @@ export class BLE extends IonicNativePlugin {
    *
    * @usage
    * ```
-   * BLE.startNotification(device_id, "FF10", "FF11").subscribe(buffer => {
+   * BLE.startNotification(device_id, 'FF10', 'FF11').subscribe(buffer => {
    *   console.log(String.fromCharCode.apply(null, new Uint8Array(buffer));
    * });
    * ```

--- a/src/@ionic-native/plugins/bluetooth-serial/index.ts
+++ b/src/@ionic-native/plugins/bluetooth-serial/index.ts
@@ -13,7 +13,7 @@ import { Observable } from 'rxjs/Observable';
  *
  *
  * // Write a string
- * this.bluetoothSerial.write("hello world").then(success, failure);
+ * this.bluetoothSerial.write('hello world').then(success, failure);
  *
  * // Array of int or bytes
  * this.bluetoothSerial.write([186, 220, 222]).then(success, failure);

--- a/src/@ionic-native/plugins/broadcaster/index.ts
+++ b/src/@ionic-native/plugins/broadcaster/index.ts
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs/Observable';
  * This plugin adds exchanging events between native code and your app.
  *
  * @usage
- * ```
+ * ```typescript
  * import { Broadcaster } from '@ionic-native/broadcaster';
  *
  * constructor(private broadcaster: Broadcaster) { }

--- a/src/@ionic-native/plugins/browser-tab/index.ts
+++ b/src/@ionic-native/plugins/browser-tab/index.ts
@@ -7,7 +7,7 @@ import { Injectable } from '@angular/core';
  * This plugin provides an interface to in-app browser tabs that exist on some mobile platforms, specifically [Custom Tabs](http://developer.android.com/tools/support-library/features.html#custom-tabs) on Android (including the [Chrome Custom Tabs](https://developer.chrome.com/multidevice/android/customtabs) implementation), and [SFSafariViewController](https://developer.apple.com/library/ios/documentation/SafariServices/Reference/SFSafariViewController_Ref/) on iOS.
  *
  * @usage
- * ```
+ * ```typescript
  * import { BrowserTab } from '@ionic-native/browser-tab';
  *
  * constructor(private browserTab: BrowserTab) {

--- a/src/@ionic-native/plugins/calendar/index.ts
+++ b/src/@ionic-native/plugins/calendar/index.ts
@@ -59,7 +59,7 @@ export interface CalendarOptions {
  *
  *
  * @usage
- * ```
+ * ```typescript
  * import { Calendar } from '@ionic-native/calendar';
  *
  * constructor(private calendar: Calendar) { }

--- a/src/@ionic-native/plugins/call-number/index.ts
+++ b/src/@ionic-native/plugins/call-number/index.ts
@@ -6,7 +6,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * Call a number directly from your Cordova/Ionic application.
  *
  * @usage
- * ```
+ * ```typescript
  * import { CallNumber } from '@ionic-native/call-number';
  *
  * constructor(private callNumber: CallNumber) { }

--- a/src/@ionic-native/plugins/camera-preview/index.ts
+++ b/src/@ionic-native/plugins/camera-preview/index.ts
@@ -39,12 +39,12 @@ export interface CameraPreviewOptions {
 }
 
 export interface CameraPreviewPictureOptions {
-    /** The width in pixels, default 0 */
-    width?: number;
-    /** The height in pixels, default 0 */
-    height?: number;
-    /** The picture quality, 0 - 100, default 85 */
-    quality?: number;
+  /** The width in pixels, default 0 */
+  width?: number;
+  /** The height in pixels, default 0 */
+  height?: number;
+  /** The picture quality, 0 - 100, default 85 */
+  quality?: number;
 }
 
 /**
@@ -251,10 +251,10 @@ export class CameraPreview extends IonicNativePlugin {
   })
   setZoom(zoom?: number): Promise<any> { return; }
 
-/**
-   * Get the maximum zoom (Android)
-   * @return {Promise<any>}
-   */
+  /**
+     * Get the maximum zoom (Android)
+     * @return {Promise<any>}
+     */
   @Cordova()
   getMaxZoom(): Promise<any> { return; }
 

--- a/src/@ionic-native/plugins/card-io/index.ts
+++ b/src/@ionic-native/plugins/card-io/index.ts
@@ -133,7 +133,7 @@ export interface CardIOResponse {
  * @name Card IO
  * @description
  * @usage
- * ```
+ * ```typescript
  * import { CardIO } from '@ionic-native/card-io';
  *
  * constructor(private cardIO: CardIO) { }

--- a/src/@ionic-native/plugins/contacts/index.ts
+++ b/src/@ionic-native/plugins/contacts/index.ts
@@ -145,16 +145,16 @@ export interface IContactName {
  */
 export class ContactName implements IContactName {
   constructor(public formatted?: string,
-              public familyName?: string,
-              public givenName?: string,
-              public middleName?: string,
-              public honorificPrefix?: string,
-              public honorificSuffix?: string) {}
+    public familyName?: string,
+    public givenName?: string,
+    public middleName?: string,
+    public honorificPrefix?: string,
+    public honorificSuffix?: string) { }
 }
 
 export interface IContactField {
   /** A string that indicates what type of field this is, home for example. */
-    type?: string;
+  type?: string;
   /** The value of the field, such as a phone number or email address. */
   value?: string;
   /** Set to true if this ContactField contains the user's preferred value. */
@@ -166,15 +166,15 @@ export interface IContactField {
  */
 export class ContactField implements IContactField {
   constructor(public type?: string,
-              public value?: string,
-              public pref?: boolean) {}
+    public value?: string,
+    public pref?: boolean) { }
 }
 
 export interface IContactAddress {
   /** Set to true if this ContactAddress contains the user's preferred value. */
   pref?: boolean;
   /** A string indicating what type of field this is, home for example. */
-    type?: string;
+  type?: string;
   /** The full address formatted for display. */
   formatted?: string;
   /** The full street address. */
@@ -194,20 +194,20 @@ export interface IContactAddress {
  */
 export class ContactAddress implements IContactAddress {
   constructor(public pref?: boolean,
-              public type?: string,
-              public formatted?: string,
-              public streetAddress?: string,
-              public locality?: string,
-              public region?: string,
-              public postalCode?: string,
-              public country?: string) {}
+    public type?: string,
+    public formatted?: string,
+    public streetAddress?: string,
+    public locality?: string,
+    public region?: string,
+    public postalCode?: string,
+    public country?: string) { }
 }
 
 export interface IContactOrganization {
   /** Set to true if this ContactOrganization contains the user's preferred value. */
   pref?: boolean;
   /** A string that indicates what type of field this is, home for example. */
-    type?: string;
+  type?: string;
   /** The name of the organization. */
   name?: string;
   /** The department the contract works for. */
@@ -226,7 +226,7 @@ export class ContactOrganization implements IContactOrganization {
     public department?: string,
     public title?: string,
     public pref?: boolean
-  ) {}
+  ) { }
 }
 
 /** Search options to filter navigator.contacts.  */
@@ -248,9 +248,9 @@ export interface IContactFindOptions {
  */
 export class ContactFindOptions implements IContactFindOptions {
   constructor(public filter?: string,
-              public multiple?: boolean,
-              public desiredFields?: string[],
-              public hasPhoneNumber?: boolean) {}
+    public multiple?: boolean,
+    public desiredFields?: string[],
+    public hasPhoneNumber?: boolean) { }
 }
 
 /**

--- a/src/@ionic-native/plugins/couchbase-lite/index.ts
+++ b/src/@ionic-native/plugins/couchbase-lite/index.ts
@@ -8,7 +8,7 @@ import { Injectable } from '@angular/core';
  * Plugin to install Couchbase Lite in your PhoneGap app on iOS or Android
  *
  * @usage
- * ```
+ * ```typescript
  * import { CouchbaseLite } from '@ionic-native/couchbase-lite';
  *
  * constructor(private couchbase: CouchbaseLite) {
@@ -38,6 +38,6 @@ export class CouchbaseLite extends IonicNativePlugin {
   @Cordova({
     callbackStyle: 'node'
   })
-  getURL(): Promise<any> { return;  }
+  getURL(): Promise<any> { return; }
 
 }

--- a/src/@ionic-native/plugins/crop/index.ts
+++ b/src/@ionic-native/plugins/crop/index.ts
@@ -5,7 +5,7 @@ import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
  * @name Crop
  * @description Crops images
  * @usage
- * ```
+ * ```typescript
  * import { Crop } from '@ionic-native/crop';
  *
  * constructor(private crop: Crop) { }
@@ -14,8 +14,8 @@ import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
  *
  * this.crop.crop('path/to/image.jpg', {quality: 75})
  *   .then(
- *     newImage => console.log("new image path is: " + newImage),
- *     error => console.error("Error cropping image", error)
+ *     newImage => console.log('new image path is: ' + newImage),
+ *     error => console.error('Error cropping image', error)
  *   );
  * ```
  */
@@ -38,6 +38,6 @@ export class Crop extends IonicNativePlugin {
   @Cordova({
     callbackOrder: 'reverse'
   })
-  crop(pathToImage: string, options?: {quality: number}): Promise<string> { return; }
+  crop(pathToImage: string, options?: { quality: number }): Promise<string> { return; }
 
 }

--- a/src/@ionic-native/plugins/device-feedback/index.ts
+++ b/src/@ionic-native/plugins/device-feedback/index.ts
@@ -7,7 +7,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * Plugin that lets you provide haptic or acoustic feedback on Android devices.
  *
  * @usage
- * ```
+ * ```typescript
  * import { DeviceFeedback } from '@ionic-native/device-feedback';
  *
  * constructor(private deviceFeedback: DeviceFeedback) { }

--- a/src/@ionic-native/plugins/file-chooser/index.ts
+++ b/src/@ionic-native/plugins/file-chooser/index.ts
@@ -8,7 +8,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * Opens the file picker on Android for the user to select a file, returns a file URI.
  *
  * @usage
- * ```
+ * ```typescript
  * import { FileChooser } from '@ionic-native/file-chooser';
  *
  * constructor(private fileChooser: FileChooser) { }

--- a/src/@ionic-native/plugins/file-opener/index.ts
+++ b/src/@ionic-native/plugins/file-opener/index.ts
@@ -7,7 +7,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * This plugin will open a file on your device file system with its default application.
  *
  * @usage
- * ```
+ * ```typescript
  * import { FileOpener } from '@ionic-native/file-opener';
  *
  * constructor(private fileOpener: FileOpener) { }
@@ -41,7 +41,7 @@ export class FileOpener extends IonicNativePlugin {
     successName: 'success',
     errorName: 'error'
   })
-  open(filePath: string, fileMIMEType: string): Promise<any> {return; }
+  open(filePath: string, fileMIMEType: string): Promise<any> { return; }
 
   /**
    * Uninstalls a package
@@ -53,7 +53,7 @@ export class FileOpener extends IonicNativePlugin {
     successName: 'success',
     errorName: 'error'
   })
-  uninstall(packageId: string): Promise<any> {return; }
+  uninstall(packageId: string): Promise<any> { return; }
 
   /**
    * Check if an app is already installed
@@ -65,6 +65,6 @@ export class FileOpener extends IonicNativePlugin {
     successName: 'success',
     errorName: 'error'
   })
-  appIsInstalled(packageId: string): Promise<any> {return; }
+  appIsInstalled(packageId: string): Promise<any> { return; }
 
 }

--- a/src/@ionic-native/plugins/file-path/index.ts
+++ b/src/@ionic-native/plugins/file-path/index.ts
@@ -10,7 +10,7 @@ declare var window: any;
  * This plugin allows you to resolve the native filesystem path for Android content URIs and is based on code in the aFileChooser library.
  *
  * @usage
- * ```
+ * ```typescript
  * import { FilePath } from '@ionic-native/file-path';
  *
  * constructor(private filePath: FilePath) { }
@@ -39,6 +39,6 @@ export class FilePath extends IonicNativePlugin {
    * @returns {Promise<string>}
    */
   @Cordova()
-  resolveNativePath(path: string): Promise<string> {return; }
+  resolveNativePath(path: string): Promise<string> { return; }
 
 }

--- a/src/@ionic-native/plugins/file/index.ts
+++ b/src/@ionic-native/plugins/file/index.ts
@@ -34,7 +34,7 @@ export interface Entry {
    * @param errorCallback   A callback that is called when errors happen.
    */
   getMetadata(successCallback: (metadata: Metadata) => void,
-              errorCallback?: (error: FileError) => void): void;
+    errorCallback?: (error: FileError) => void): void;
   /**
    * Move an entry to a different location on the file system. It is an error to try to:
    *     move a directory inside itself or to any child at any depth;move an entry into its parent if a name different from its current one isn't provided;
@@ -49,9 +49,9 @@ export interface Entry {
    * @param errorCallback   A callback that is called when errors happen.
    */
   moveTo(parent: DirectoryEntry,
-         newName?: string,
-         successCallback?: (entry: Entry) => void,
-         errorCallback?: (error: FileError) => void): void;
+    newName?: string,
+    successCallback?: (entry: Entry) => void,
+    errorCallback?: (error: FileError) => void): void;
   /**
    * Copy an entry to a different location on the file system. It is an error to try to:
    *     copy a directory inside itself or to any child at any depth;
@@ -68,9 +68,9 @@ export interface Entry {
    * @param errorCallback A callback that is called when errors happen.
    */
   copyTo(parent: DirectoryEntry,
-         newName?: string,
-         successCallback?: (entry: Entry) => void,
-         errorCallback?: (error: FileError) => void): void;
+    newName?: string,
+    successCallback?: (entry: Entry) => void,
+    errorCallback?: (error: FileError) => void): void;
   /**
    * Returns a URL that can be used as the src attribute of a <video> or <audio> tag.
    * If that is not possible, construct a cdvfile:// URL.
@@ -88,14 +88,14 @@ export interface Entry {
    * @param errorCallback   A callback that is called when errors happen.
    */
   remove(successCallback: () => void,
-         errorCallback?: (error: FileError) => void): void;
+    errorCallback?: (error: FileError) => void): void;
   /**
    * Look up the parent DirectoryEntry containing this Entry. If this Entry is the root of its filesystem, its parent is itself.
    * @param successCallback A callback that is called with the time of the last modification.
    * @param errorCallback   A callback that is called when errors happen.
    */
   getParent(successCallback: (entry: Entry) => void,
-            errorCallback?: (error: FileError) => void): void;
+    errorCallback?: (error: FileError) => void): void;
 }
 
 /** This interface supplies information about the state of a file or directory. */
@@ -126,8 +126,8 @@ export interface DirectoryEntry extends Entry {
    * @param errorCallback   A callback that is called when errors happen.
    */
   getFile(path: string, options?: Flags,
-          successCallback?: (entry: FileEntry) => void,
-          errorCallback?: (error: FileError) => void): void;
+    successCallback?: (entry: FileEntry) => void,
+    errorCallback?: (error: FileError) => void): void;
   /**
    * Creates or looks up a directory.
    * @param path    Either an absolute path or a relative path from this DirectoryEntry
@@ -142,8 +142,8 @@ export interface DirectoryEntry extends Entry {
    * @param errorCallback   A callback that is called when errors happen.
    */
   getDirectory(path: string, options?: Flags,
-               successCallback?: (entry: DirectoryEntry) => void,
-               errorCallback?: (error: FileError) => void): void;
+    successCallback?: (entry: DirectoryEntry) => void,
+    errorCallback?: (error: FileError) => void): void;
   /**
    * Deletes a directory and all of its contents, if any. In the event of an error (e.g. trying
    * to delete a directory that contains a file that cannot be removed), some of the contents
@@ -152,7 +152,7 @@ export interface DirectoryEntry extends Entry {
    * @param errorCallback   A callback that is called when errors happen.
    */
   removeRecursively(successCallback: () => void,
-                    errorCallback?: (error: FileError) => void): void;
+    errorCallback?: (error: FileError) => void): void;
 }
 
 export interface RemoveResult {
@@ -196,7 +196,7 @@ export interface DirectoryReader {
    * @param errorCallback   A callback indicating that there was an error reading from the Directory.
    */
   readEntries(successCallback: (entries: Entry[]) => void,
-              errorCallback?: (error: FileError) => void): void;
+    errorCallback?: (error: FileError) => void): void;
 }
 
 /** This interface represents a file on a file system. */
@@ -207,14 +207,14 @@ export interface FileEntry extends Entry {
    * @param errorCallback   A callback that is called when errors happen.
    */
   createWriter(successCallback: (writer: FileWriter) => void,
-               errorCallback?: (error: FileError) => void): void;
+    errorCallback?: (error: FileError) => void): void;
   /**
    * Returns a File that represents the current state of the file that this FileEntry represents.
    * @param successCallback A callback that is called with the File.
    * @param errorCallback   A callback that is called when errors happen.
    */
   file(successCallback: (file: File) => void,
-       errorCallback?: (error: FileError) => void): void;
+    errorCallback?: (error: FileError) => void): void;
 }
 
 /**
@@ -313,7 +313,7 @@ export declare var FileReader: {
   LOADING: number;
   DONE: number;
 
-  new(): FileReader;
+  new (): FileReader;
 };
 
 export interface FileError {
@@ -545,7 +545,7 @@ export class File extends IonicNativePlugin {
 
     return this.resolveDirectoryUrl(path)
       .then((fse) => {
-        return this.getDirectory(fse, dirName, {create: false});
+        return this.getDirectory(fse, dirName, { create: false });
       })
       .then((de) => {
         return this.remove(de);
@@ -562,7 +562,7 @@ export class File extends IonicNativePlugin {
    * @returns {Promise<DirectoryEntry|Entry>} Returns a Promise that resolves to the new DirectoryEntry object or rejects with an error.
    */
   @CordovaCheck()
-  moveDir(path: string, dirName: string, newPath: string, newDirName: string): Promise<DirectoryEntry|Entry> {
+  moveDir(path: string, dirName: string, newPath: string, newDirName: string): Promise<DirectoryEntry | Entry> {
     newDirName = newDirName || dirName;
 
     if ((/^\//.test(newDirName))) {
@@ -573,7 +573,7 @@ export class File extends IonicNativePlugin {
 
     return this.resolveDirectoryUrl(path)
       .then((fse) => {
-        return this.getDirectory(fse, dirName, {create: false});
+        return this.getDirectory(fse, dirName, { create: false });
       })
       .then((srcde) => {
         return this.resolveDirectoryUrl(newPath)
@@ -602,7 +602,7 @@ export class File extends IonicNativePlugin {
 
     return this.resolveDirectoryUrl(path)
       .then((fse) => {
-        return this.getDirectory(fse, dirName, {create: false});
+        return this.getDirectory(fse, dirName, { create: false });
       })
       .then((srcde) => {
         return this.resolveDirectoryUrl(newPath)
@@ -629,7 +629,7 @@ export class File extends IonicNativePlugin {
 
     return this.resolveDirectoryUrl(path)
       .then((fse) => {
-        return this.getDirectory(fse, dirName, {create: false, exclusive: false});
+        return this.getDirectory(fse, dirName, { create: false, exclusive: false });
       })
       .then((de) => {
         let reader = de.createReader();
@@ -654,7 +654,7 @@ export class File extends IonicNativePlugin {
 
     return this.resolveDirectoryUrl(path)
       .then((fse) => {
-        return this.getDirectory(fse, dirName, {create: false});
+        return this.getDirectory(fse, dirName, { create: false });
       })
       .then((de) => {
         return this.rimraf(de);
@@ -737,7 +737,7 @@ export class File extends IonicNativePlugin {
 
     return this.resolveDirectoryUrl(path)
       .then((fse) => {
-        return this.getFile(fse, fileName, {create: false});
+        return this.getFile(fse, fileName, { create: false });
       })
       .then((fe) => {
         return this.remove(fe);
@@ -754,7 +754,7 @@ export class File extends IonicNativePlugin {
    */
   @CordovaCheck()
   writeFile(path: string, fileName: string,
-                   text: string | Blob | ArrayBuffer, options: WriteOptions = {}): Promise<any> {
+    text: string | Blob | ArrayBuffer, options: WriteOptions = {}): Promise<any> {
     if ((/^\//.test(fileName))) {
       const err = new FileError(5);
       err.message = 'file-name cannot start with \/';
@@ -829,7 +829,7 @@ export class File extends IonicNativePlugin {
 
     return this.resolveDirectoryUrl(path)
       .then((directoryEntry: DirectoryEntry) => {
-        return this.getFile(directoryEntry, file, {create: false});
+        return this.getFile(directoryEntry, file, { create: false });
       })
       .then((fileEntry: FileEntry) => {
         let reader = new FileReader();
@@ -840,7 +840,7 @@ export class File extends IonicNativePlugin {
             } else if (reader.error !== undefined || reader.error !== null) {
               reject(reader.error);
             } else {
-              reject({code: null, message: 'READER_ONLOADEND_ERR'});
+              reject({ code: null, message: 'READER_ONLOADEND_ERR' });
             }
           };
           fileEntry.file(file => {
@@ -871,7 +871,7 @@ export class File extends IonicNativePlugin {
 
     return this.resolveDirectoryUrl(path)
       .then((directoryEntry: DirectoryEntry) => {
-        return this.getFile(directoryEntry, file, {create: false});
+        return this.getFile(directoryEntry, file, { create: false });
       })
       .then((fileEntry: FileEntry) => {
         let reader = new FileReader();
@@ -882,7 +882,7 @@ export class File extends IonicNativePlugin {
             } else if (reader.error !== undefined || reader.error !== null) {
               reject(reader.error);
             } else {
-              reject({code: null, message: 'READER_ONLOADEND_ERR'});
+              reject({ code: null, message: 'READER_ONLOADEND_ERR' });
             }
           };
 
@@ -914,7 +914,7 @@ export class File extends IonicNativePlugin {
 
     return this.resolveDirectoryUrl(path)
       .then((directoryEntry: DirectoryEntry) => {
-        return this.getFile(directoryEntry, file, {create: false});
+        return this.getFile(directoryEntry, file, { create: false });
       })
       .then((fileEntry: FileEntry) => {
         let reader = new FileReader();
@@ -925,7 +925,7 @@ export class File extends IonicNativePlugin {
             } else if (reader.error !== undefined || reader.error !== null) {
               reject(reader.error);
             } else {
-              reject({code: null, message: 'READER_ONLOADEND_ERR'});
+              reject({ code: null, message: 'READER_ONLOADEND_ERR' });
             }
           };
 
@@ -955,7 +955,7 @@ export class File extends IonicNativePlugin {
 
     return this.resolveDirectoryUrl(path)
       .then((directoryEntry: DirectoryEntry) => {
-        return this.getFile(directoryEntry, file, {create: false});
+        return this.getFile(directoryEntry, file, { create: false });
       })
       .then((fileEntry: FileEntry) => {
         let reader = new FileReader();
@@ -966,7 +966,7 @@ export class File extends IonicNativePlugin {
             } else if (reader.error !== undefined || reader.error !== null) {
               reject(reader.error);
             } else {
-              reject({code: null, message: 'READER_ONLOADEND_ERR'});
+              reject({ code: null, message: 'READER_ONLOADEND_ERR' });
             }
           };
 
@@ -1001,7 +1001,7 @@ export class File extends IonicNativePlugin {
 
     return this.resolveDirectoryUrl(path)
       .then((fse) => {
-        return this.getFile(fse, fileName, {create: false});
+        return this.getFile(fse, fileName, { create: false });
       })
       .then((srcfe) => {
         return this.resolveDirectoryUrl(newPath)
@@ -1032,7 +1032,7 @@ export class File extends IonicNativePlugin {
 
     return this.resolveDirectoryUrl(path)
       .then((fse) => {
-        return this.getFile(fse, fileName, {create: false});
+        return this.getFile(fse, fileName, { create: false });
       })
       .then((srcfe) => {
         return this.resolveDirectoryUrl(newPath)
@@ -1048,7 +1048,7 @@ export class File extends IonicNativePlugin {
   private fillErrorMessage(err: FileError): void {
     try {
       err.message = this.cordovaFileError[err.code];
-    } catch (e) {}
+    } catch (e) { }
   }
 
   /**
@@ -1144,7 +1144,7 @@ export class File extends IonicNativePlugin {
   private remove(fe: Entry): Promise<RemoveResult> {
     return new Promise<RemoveResult>((resolve, reject) => {
       fe.remove(() => {
-        resolve({success: true, fileRemoved: fe});
+        resolve({ success: true, fileRemoved: fe });
       }, (err) => {
         this.fillErrorMessage(err);
         reject(err);
@@ -1200,7 +1200,7 @@ export class File extends IonicNativePlugin {
   private rimraf(de: DirectoryEntry): Promise<RemoveResult> {
     return new Promise<RemoveResult>((resolve, reject) => {
       de.removeRecursively(() => {
-        resolve({success: true, fileRemoved: de});
+        resolve({ success: true, fileRemoved: de });
       }, (err) => {
         this.fillErrorMessage(err);
         reject(err);

--- a/src/@ionic-native/plugins/fingerprint-aio/index.ts
+++ b/src/@ionic-native/plugins/fingerprint-aio/index.ts
@@ -35,8 +35,8 @@ export interface FingerprintOptions {
  * ...
  *
  * this.faio.show({
- *     clientId: "Fingerprint-Demo",
- *     clientSecret: "password", //Only necessary for Android
+ *     clientId: 'Fingerprint-Demo',
+ *     clientSecret: 'password', //Only necessary for Android
  *     disableBackup:true  //Only for Android(optional)
  * })
  * .then((result: any) => console.log(result))

--- a/src/@ionic-native/plugins/firebase/index.ts
+++ b/src/@ionic-native/plugins/firebase/index.ts
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs/Observable';
  * This plugin brings push notifications, analytics, event tracking, crash reporting and more from Google Firebase to your Cordova project! Android and iOS supported (including iOS 10).
  *
  * @usage
- * ```
+ * ```typescript
  * import { Firebase } from '@ionic-native/firebase';
  *
  * constructor(private firebase: Firebase) { }
@@ -68,10 +68,10 @@ export class Firebase extends IonicNativePlugin {
   })
   grantPermission(): Promise<any> { return; }
 
-    /**
-   * Check permission to receive push notifications
-   * @return {Promise<any>}
-   */
+  /**
+ * Check permission to receive push notifications
+ * @return {Promise<any>}
+ */
   @Cordova({
     platforms: ['iOS']
   })

--- a/src/@ionic-native/plugins/flashlight/index.ts
+++ b/src/@ionic-native/plugins/flashlight/index.ts
@@ -17,7 +17,6 @@ import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
  *
  * this.flashlight.switchOn();
  *
- *
  * ```
  */
 @Plugin({

--- a/src/@ionic-native/plugins/flurry-analytics/index.ts
+++ b/src/@ionic-native/plugins/flurry-analytics/index.ts
@@ -78,7 +78,7 @@ export interface FlurryAnalyticsLocation {
  * This plugin connects to Flurry Analytics SDK
  *
  * @usage
- * ```
+ * ```typescript
  * import { FlurryAnalytics } from 'ionic-native/flurry-analytics';
  *
  * constructor(private flurryAnalytics: FlurryAnalytics) { }

--- a/src/@ionic-native/plugins/geofence/index.ts
+++ b/src/@ionic-native/plugins/geofence/index.ts
@@ -9,7 +9,7 @@ declare var window: any;
  * @description Monitors circular geofences around latitude/longitude coordinates, and sends a notification to the user when the boundary of a geofence is crossed. Notifications can be sent when the user enters and/or exits a geofence.
  * Geofences persist after device reboot. Geofences will be monitored even when the app is not running.
  * @usage
- * ```
+ * ```typescript
  * import { Geofence } from '@ionic-native/geofence';
  *
  * ...
@@ -28,15 +28,15 @@ declare var window: any;
  * private addGeofence() {
  *   //options describing geofence
  *   let fence = {
- *     id: "69ca1b88-6fbe-4e80-a4d4-ff4d3748acdb", //any unique ID
+ *     id: '69ca1b88-6fbe-4e80-a4d4-ff4d3748acdb', //any unique ID
  *     latitude:       37.285951, //center of geofence radius
  *     longitude:      -121.936650,
  *     radius:         100, //radius to edge of geofence
  *     transitionType: 3, //see 'Transition Types' below
  *     notification: { //notification settings
  *         id:             1, //any unique ID
- *         title:          "You crossed a fence", //notification title
- *         text:           "You just arrived to Gliwice city center.", //notification body
+ *         title:          'You crossed a fence', //notification title
+ *         text:           'You just arrived to Gliwice city center.', //notification body
  *         openAppOnClick: true //open app when notification is tapped
  *     }
  *   }
@@ -148,7 +148,7 @@ export class Geofence extends IonicNativePlugin {
 
     return new Observable<any>((observer) => {
       window && window.geofence && (window.geofence.onTransitionReceived = observer.next.bind(observer));
-      return () => window.geofence.onTransitionReceived = () => {};
+      return () => window.geofence.onTransitionReceived = () => { };
     });
 
   }
@@ -162,7 +162,7 @@ export class Geofence extends IonicNativePlugin {
 
     return new Observable<any>((observer) => {
       window && window.geofence && (window.geofence.onNotificationClicked = observer.next.bind(observer));
-        return () => window.geofence.onNotificationClicked = () => {};
+      return () => window.geofence.onNotificationClicked = () => { };
     });
 
   }

--- a/src/@ionic-native/plugins/geolocation/index.ts
+++ b/src/@ionic-native/plugins/geolocation/index.ts
@@ -74,7 +74,7 @@ export interface PositionError {
   /**
    * A message that can describe the error that occurred
    */
-   message: string;
+  message: string;
 
 }
 

--- a/src/@ionic-native/plugins/google-maps/index.ts
+++ b/src/@ionic-native/plugins/google-maps/index.ts
@@ -42,12 +42,12 @@ export const GoogleMapsAnimation = {
  * @hidden
  */
 export const GoogleMapsMapTypeId = {
-    HYBRID: 'MAP_TYPE_HYBRID',
-    NONE: 'MAP_TYPE_NONE',
-    NORMAL: 'MAP_TYPE_NORMAL',
-    ROADMAP: 'MAP_TYPE_ROADMAP',
-    SATELLITE: 'MAP_TYPE_SATELLITE',
-    TERAIN: 'MAP_TYPE_TERRAIN'
+  HYBRID: 'MAP_TYPE_HYBRID',
+  NONE: 'MAP_TYPE_NONE',
+  NORMAL: 'MAP_TYPE_NORMAL',
+  ROADMAP: 'MAP_TYPE_ROADMAP',
+  SATELLITE: 'MAP_TYPE_SATELLITE',
+  TERAIN: 'MAP_TYPE_TERRAIN'
 };
 
 /**
@@ -214,13 +214,13 @@ export class GoogleMap {
   @InstanceCheck()
   addMarker(options: MarkerOptions): Promise<Marker | any> {
     return new Promise<Marker>((resolve, reject) => {
-        this._objectInstance.addMarker(options, (marker: any) => {
-          if (marker) {
-            resolve(new Marker(marker));
-          } else {
-            reject();
-          }
-        });
+      this._objectInstance.addMarker(options, (marker: any) => {
+        if (marker) {
+          resolve(new Marker(marker));
+        } else {
+          reject();
+        }
+      });
     });
   }
 
@@ -230,13 +230,13 @@ export class GoogleMap {
   @InstanceCheck()
   addCircle(options: CircleOptions): Promise<Circle | any> {
     return new Promise<Circle>((resolve, reject) => {
-        this._objectInstance.addCircle(options, (circle: any) => {
-          if (circle) {
-            resolve(new Circle(circle));
-          } else {
-            reject();
-          }
-        });
+      this._objectInstance.addCircle(options, (circle: any) => {
+        if (circle) {
+          resolve(new Circle(circle));
+        } else {
+          reject();
+        }
+      });
     });
   }
 
@@ -246,13 +246,13 @@ export class GoogleMap {
   @InstanceCheck()
   addPolygon(options: PolygonOptions): Promise<Polygon | any> {
     return new Promise<Polygon>((resolve, reject) => {
-        this._objectInstance.addPolygon(options, (polygon: any) => {
-          if (polygon) {
-            resolve(new Polygon(polygon));
-          } else {
-            reject();
-          }
-        });
+      this._objectInstance.addPolygon(options, (polygon: any) => {
+        if (polygon) {
+          resolve(new Polygon(polygon));
+        } else {
+          reject();
+        }
+      });
     });
   }
 
@@ -262,13 +262,13 @@ export class GoogleMap {
   @InstanceCheck()
   addPolyline(options: PolylineOptions): Promise<Polyline | any> {
     return new Promise<Polyline>((resolve, reject) => {
-        this._objectInstance.addPolyline(options, (polyline: any) => {
-          if (polyline) {
-            resolve(new Polyline(polyline));
-          } else {
-            reject();
-          }
-        });
+      this._objectInstance.addPolyline(options, (polyline: any) => {
+        if (polyline) {
+          resolve(new Polyline(polyline));
+        } else {
+          reject();
+        }
+      });
     });
   }
 
@@ -278,13 +278,13 @@ export class GoogleMap {
   @InstanceCheck()
   addTileOverlay(options: TileOverlayOptions): Promise<TileOverlay | any> {
     return new Promise<TileOverlay>((resolve, reject) => {
-        this._objectInstance.addTileOverlay(options, (tileOverlay: any) => {
-          if (tileOverlay) {
-            resolve(new TileOverlay(tileOverlay));
-          } else {
-            reject();
-          }
-        });
+      this._objectInstance.addTileOverlay(options, (tileOverlay: any) => {
+        if (tileOverlay) {
+          resolve(new TileOverlay(tileOverlay));
+        } else {
+          reject();
+        }
+      });
     });
   }
 
@@ -294,13 +294,13 @@ export class GoogleMap {
   @InstanceCheck()
   addGroundOverlay(options: GroundOverlayOptions): Promise<GroundOverlay | any> {
     return new Promise<GroundOverlay>((resolve, reject) => {
-        this._objectInstance.addGroundOverlay(options, (groundOverlay: any) => {
-          if (groundOverlay) {
-            resolve(new GroundOverlay(groundOverlay));
-          } else {
-            reject();
-          }
-        });
+      this._objectInstance.addGroundOverlay(options, (groundOverlay: any) => {
+        if (groundOverlay) {
+          resolve(new GroundOverlay(groundOverlay));
+        } else {
+          reject();
+        }
+      });
     });
   }
 
@@ -310,13 +310,13 @@ export class GoogleMap {
   @InstanceCheck()
   addKmlOverlay(options: KmlOverlayOptions): Promise<KmlOverlay | any> {
     return new Promise<KmlOverlay>((resolve, reject) => {
-        this._objectInstance.addKmlOverlay(options, (kmlOverlay: any) => {
-          if (kmlOverlay) {
-            resolve(new KmlOverlay(kmlOverlay));
-          } else {
-            reject();
-          }
-        });
+      this._objectInstance.addKmlOverlay(options, (kmlOverlay: any) => {
+        if (kmlOverlay) {
+          resolve(new KmlOverlay(kmlOverlay));
+        } else {
+          reject();
+        }
+      });
     });
   }
 
@@ -370,7 +370,7 @@ export class GoogleMap {
  * @name Google Maps
  * @description This plugin uses the native Google Maps SDK
  * @usage
- * ```
+ * ```typescript
  * import {
  *  GoogleMaps,
  *  GoogleMap,

--- a/src/@ionic-native/plugins/gyroscope/index.ts
+++ b/src/@ionic-native/plugins/gyroscope/index.ts
@@ -43,7 +43,7 @@ export interface GyroscopeOptions {
  * @name Gyroscope
  * @description Read Gyroscope sensor data
  * @usage
- * ```
+ * ```typescript
  * import { Gyroscope, GyroscopeOrientation, GyroscopeOptions } from '@ionic-native/gyroscope';
  *
  *
@@ -89,7 +89,7 @@ export class Gyroscope extends IonicNativePlugin {
    * @return {Observable<GyroscopeOrientation>} Returns an Observable that resolves GyroscopeOrientation
    */
   watch(options?: GyroscopeOptions): Observable<GyroscopeOrientation> {
-    return new Observable<GyroscopeOrientation> (
+    return new Observable<GyroscopeOrientation>(
       (observer: any) => {
         let watchId = navigator.gyroscope.watch(observer.next.bind(observer), observer.next.bind(observer), options);
         return () => navigator.gyroscope.clearWatch(watchId);

--- a/src/@ionic-native/plugins/header-color/index.ts
+++ b/src/@ionic-native/plugins/header-color/index.ts
@@ -14,7 +14,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  *
  * ...
  *
- * this.headerColor.tint("#becb29");
+ * this.headerColor.tint('#becb29');
  * ```
  */
 @Plugin({

--- a/src/@ionic-native/plugins/health/index.ts
+++ b/src/@ionic-native/plugins/health/index.ts
@@ -160,7 +160,7 @@ export interface HealthData {
  * A plugin that abstracts fitness and health repositories like Apple HealthKit or Google Fit.
  *
  * @usage
- * ```
+ * ```typescript
  * import { Health } from '@ionic-native/health';
  *
  *

--- a/src/@ionic-native/plugins/http/index.ts
+++ b/src/@ionic-native/plugins/http/index.ts
@@ -30,7 +30,7 @@ export interface HTTPResponse {
  * - SSL Pinning
  *
  * @usage
- * ```
+ * ```typescript
  * import { HTTP } from '@ionic-native/http';
  *
  * constructor(private http: HTTP) { }

--- a/src/@ionic-native/plugins/ibeacon/index.ts
+++ b/src/@ionic-native/plugins/ibeacon/index.ts
@@ -434,7 +434,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved as soon as the
    * native layer acknowledged the request and started to send events.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   onDomDelegateReady(): Promise<void> { return; }
 
   /**
@@ -442,7 +442,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<boolean>} Returns a promise which is resolved with a {Boolean}
    * indicating whether bluetooth is active.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   isBluetoothEnabled(): Promise<boolean> { return; }
 
   /**
@@ -451,7 +451,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved when Bluetooth
    * could be enabled. If not, the promise will be rejected with an error.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   enableBluetooth(): Promise<void> { return; }
 
   /**
@@ -460,7 +460,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved when Bluetooth
    * could be enabled. If not, the promise will be rejected with an error.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   disableBluetooth(): Promise<void> { return; }
 
   /**
@@ -480,7 +480,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<string>} Returns a promise which is resolved as soon as the
    * native layer acknowledged the dispatch of the monitoring request.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   startMonitoringForRegion(region: BeaconRegion): Promise<string> { return; }
 
   /**
@@ -497,7 +497,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved as soon as the
    * native layer acknowledged the dispatch of the request to stop monitoring.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   stopMonitoringForRegion(region: BeaconRegion): Promise<void> { return; }
 
   /**
@@ -513,7 +513,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved as soon as the
    * native layer acknowledged the dispatch of the request to stop monitoring.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   requestStateForRegion(region: Region): Promise<void> { return; }
 
 
@@ -531,7 +531,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved as soon as the
    * native layer acknowledged the dispatch of the monitoring request.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   startRangingBeaconsInRegion(region: BeaconRegion): Promise<void> { return; }
 
   /**
@@ -548,7 +548,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved as soon as the
    * native layer acknowledged the dispatch of the request to stop monitoring.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   stopRangingBeaconsInRegion(region: BeaconRegion): Promise<void> { return; }
 
   /**
@@ -557,7 +557,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<IBeaconPluginResult>} Returns a promise which is resolved with the
    * requested authorization status.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   getAuthorizationStatus(): Promise<IBeaconPluginResult> { return; }
 
   /**
@@ -569,7 +569,7 @@ export class IBeacon extends IonicNativePlugin {
    * If you are using this plugin on Android devices only, you will never have to use this, nor {@code requestAlwaysAuthorization}
    * @returns {Promise<void>} Returns a promise that is resolved when the request dialog is shown.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   requestWhenInUseAuthorization(): Promise<void> { return; }
 
 
@@ -579,7 +579,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved when the native layer
    * shows the request dialog.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   requestAlwaysAuthorization(): Promise<void> { return; }
 
   /**
@@ -587,7 +587,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<Region[]>} Returns a promise which is resolved with an {Array}
    * of {Region} instances that are being monitored by the native layer.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   getMonitoredRegions(): Promise<Region[]> { return; }
 
   /**
@@ -595,7 +595,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<Region[]>} Returns a promise which is resolved with an {Array}
    * of {Region} instances that are being ranged by the native layer.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   getRangedRegions(): Promise<Region[]> { return; }
 
   /**
@@ -603,7 +603,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<boolean>} Returns a promise which is resolved with a {Boolean}
    * indicating whether ranging is available or not.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   isRangingAvailable(): Promise<boolean> { return; }
 
   /**
@@ -615,7 +615,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<boolean>} Returns a promise which is resolved with a {Boolean}
    * indicating whether the region type is supported or not.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   isMonitoringAvailableForClass(region: Region): Promise<boolean> { return; }
 
   /**
@@ -635,7 +635,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved as soon as the
    * native layer acknowledged the dispatch of the advertising request.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   startAdvertising(region: Region, measuredPower: number): Promise<void> { return; }
 
   /**
@@ -646,7 +646,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved as soon as the
    * native layer acknowledged the dispatch of the request to stop advertising.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   stopAdvertising(region: Region): Promise<void> { return; }
 
   /**
@@ -654,7 +654,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved with a {Boolean}
    * indicating whether advertising is available or not.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   isAdvertisingAvailable(): Promise<boolean> { return; }
 
   /**
@@ -662,7 +662,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved with a {Boolean}
    * indicating whether advertising is active.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   isAdvertising(): Promise<boolean> { return; }
 
   /**
@@ -672,7 +672,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved as soon as the
    * native layer has set the logging level accordingly.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   disableDebugLogs(): Promise<void> { return; }
 
   /**
@@ -683,7 +683,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved as soon as the
    * native layer has set the flag to enabled.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   enableDebugNotifications(): Promise<void> { return; }
 
   /**
@@ -693,7 +693,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved as soon as the
    * native layer has set the flag to disabled.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   disableDebugNotifications(): Promise<void> { return; }
 
   /**
@@ -703,7 +703,7 @@ export class IBeacon extends IonicNativePlugin {
    * @returns {Promise<void>} Returns a promise which is resolved as soon as the
    * native layer has set the logging level accordingly.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   enableDebugLogs(): Promise<void> { return; }
 
   /**
@@ -716,7 +716,7 @@ export class IBeacon extends IonicNativePlugin {
    * message received by the native layer for appending. The returned message
    * is expected to be equivalent to the one provided in the original call.
    */
-  @Cordova({otherPromise: true})
+  @Cordova({ otherPromise: true })
   appendToDeviceLog(message: string): Promise<void> { return; }
 
 }

--- a/src/@ionic-native/plugins/image-resizer/index.ts
+++ b/src/@ionic-native/plugins/image-resizer/index.ts
@@ -2,39 +2,39 @@ import { Injectable } from '@angular/core';
 import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
 
 export interface ImageResizerOptions {
-    /**
-     * The URI for the image on the device to get scaled
-     */
-    uri: string;
+  /**
+   * The URI for the image on the device to get scaled
+   */
+  uri: string;
 
-    /**
-     * The width of the new image
-     */
-    width: number;
+  /**
+   * The width of the new image
+   */
+  width: number;
 
-    /**
-     * The height of the new image
-     */
-    height: number;
+  /**
+   * The height of the new image
+   */
+  height: number;
 
-    /**
-     * The name of the folder the image should be put
-     * (Android only)
-     */
-    folderName?: string;
+  /**
+   * The name of the folder the image should be put
+   * (Android only)
+   */
+  folderName?: string;
 
-    /**
-     *
-     * Quality given as Number for the quality of the new image
-     * (Android and iOS only)
-     */
-    quality?: number;
+  /**
+   *
+   * Quality given as Number for the quality of the new image
+   * (Android and iOS only)
+   */
+  quality?: number;
 
-    /**
-     * A custom name for the file. Default name is a timestamp
-     * (Android and Windows only)
-     */
-    fileName?: string;
+  /**
+   * A custom name for the file. Default name is a timestamp
+   * (Android and Windows only)
+   */
+  fileName?: string;
 }
 
 /**

--- a/src/@ionic-native/plugins/in-app-purchase/index.ts
+++ b/src/@ionic-native/plugins/in-app-purchase/index.ts
@@ -8,7 +8,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * A lightweight Cordova plugin for in app purchases on iOS/Android.
  *
  * @usage
- * ```ts
+ * ```typescript
  * import { InAppPurchase } from '@ionic-native/in-app-purchase';
  *
  * constructor(private iap: InAppPurchase) { }
@@ -44,7 +44,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  *
  * @advanced
  *
- * ```ts
+ * ```typescript
  * // fist buy the product...
  * this.iap
  *   .buy('consumable_prod1')
@@ -81,7 +81,7 @@ export class InAppPurchase extends IonicNativePlugin {
   @Cordova({
     otherPromise: true
   })
-  buy(productId: string): Promise<{transactionId: string, receipt: string, signature: string, productType: string}> { return; }
+  buy(productId: string): Promise<{ transactionId: string, receipt: string, signature: string, productType: string }> { return; }
 
   /**
    * Same as buy, but for subscription based products.
@@ -91,7 +91,7 @@ export class InAppPurchase extends IonicNativePlugin {
   @Cordova({
     otherPromise: true
   })
-  subscribe(productId: string): Promise<{transactionId: string, receipt: string, signature: string, productType: string}> { return; }
+  subscribe(productId: string): Promise<{ transactionId: string, receipt: string, signature: string, productType: string }> { return; }
 
   /**
    * Call this function after purchasing a "consumable" product to mark it as consumed. On Android, you must consume products that you want to let the user purchase multiple times. If you will not consume the product after a purchase, the next time you will attempt to purchase it you will get the error message:

--- a/src/@ionic-native/plugins/instagram/index.ts
+++ b/src/@ionic-native/plugins/instagram/index.ts
@@ -6,7 +6,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * @description Share a photo with the instagram app
  *
  * @usage
- * ```
+ * ```typescript
  * import { Instagram } from '@ionic-native/instagram';
  *
  * constructor(private instagram: Instagram) { }
@@ -37,7 +37,7 @@ export class Instagram extends IonicNativePlugin {
   @Cordova({
     callbackStyle: 'node'
   })
-  isInstalled(): Promise<boolean|string> { return; }
+  isInstalled(): Promise<boolean | string> { return; }
 
   /**
    * Share an image on Instagram

--- a/src/@ionic-native/plugins/intel-security/index.ts
+++ b/src/@ionic-native/plugins/intel-security/index.ts
@@ -40,7 +40,7 @@ export interface IntelSecurityDataOptions {
  * For more information please visit the [API documentation](https://software.intel.com/en-us/app-security-api/api).
  *
  * @usage
- * ```
+ * ```typescript
  * import { IntelSecurity } from '@ionic-native/intel-security';
  * ...
  * constructor(private intelSecurity: IntelSecurity) { }

--- a/src/@ionic-native/plugins/is-debug/index.ts
+++ b/src/@ionic-native/plugins/is-debug/index.ts
@@ -8,7 +8,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * Debug mode is when the app is built and installed locally via xcode / eclipse / the cordova cli etc, compared to release mode when the app was downloaded from the app / play store via an end user.
  *
  * @usage
- * ```
+ * ```typescript
  * import { IsDebug } from '@ionic-native/is-debug';
  *
  * constructor(private isDebug: IsDebug) { }

--- a/src/@ionic-native/plugins/jins-meme/index.ts
+++ b/src/@ionic-native/plugins/jins-meme/index.ts
@@ -10,7 +10,7 @@ declare var cordova: any;
  * Implementation of the JINS MEME SDK
  *
  * @usage
- * ```
+ * ```typescript
  * import { JinsMeme } from '@ionic-native/jins-meme';
  *
  * constructor(private jinsMeme: JinsMeme) { }
@@ -75,11 +75,11 @@ export class JinsMeme extends IonicNativePlugin {
     observable: true
   })
   connect(target: string): Observable<any> {
-     return new Observable<any>((observer: any) => {
-       let data = cordova.plugins.JinsMemePlugin.connect(target, observer.next.bind(observer), observer.complete.bind(observer), observer.error.bind(observer));
-       return () => console.log(data);
-     });
-    }
+    return new Observable<any>((observer: any) => {
+      let data = cordova.plugins.JinsMemePlugin.connect(target, observer.next.bind(observer), observer.complete.bind(observer), observer.error.bind(observer));
+      return () => console.log(data);
+    });
+  }
   /**
    * Set auto connection mode.
    *@param {Boolean} flag
@@ -109,10 +109,10 @@ export class JinsMeme extends IonicNativePlugin {
     clearWithArgs: true
   })
   startDataReport(): Observable<any> { return; }
-   /**
-   * Stops receiving data.
-   *@returns {Promise<any>}
-   */
+  /**
+  * Stops receiving data.
+  *@returns {Promise<any>}
+  */
   @Cordova()
   stopDataReport(): Promise<any> { return; }
   /**

--- a/src/@ionic-native/plugins/keyboard/index.ts
+++ b/src/@ionic-native/plugins/keyboard/index.ts
@@ -34,7 +34,7 @@ export class Keyboard extends IonicNativePlugin {
    * Hide the keyboard accessory bar with the next, previous and done buttons.
    * @param hide {boolean}
    */
-   @Cordova({sync: true})
+  @Cordova({ sync: true })
   hideKeyboardAccessoryBar(hide: boolean): void { }
 
   /**

--- a/src/@ionic-native/plugins/keychain/index.ts
+++ b/src/@ionic-native/plugins/keychain/index.ts
@@ -56,7 +56,7 @@ export class Keychain extends IonicNativePlugin {
   @Cordova({
     callbackOrder: 'reverse'
   })
-  set(key: string, value: string|number|boolean, useTouchID?: boolean): Promise<any> { return; }
+  set(key: string, value: string | number | boolean, useTouchID?: boolean): Promise<any> { return; }
 
   /**
    * Gets a JSON value for a key

--- a/src/@ionic-native/plugins/launch-review/index.ts
+++ b/src/@ionic-native/plugins/launch-review/index.ts
@@ -10,7 +10,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * On iOS, the plugin opens the app's storepage in the App Store and focuses the Review tab, where the user can leave a review by pressing "Write a review".
  *
  * @usage
- * ```
+ * ```typescript
  * import { LaunchReview } from '@ionic-native/launch-review';
  *
  * constructor(private launchReview: LaunchReview) { }

--- a/src/@ionic-native/plugins/linkedin/index.ts
+++ b/src/@ionic-native/plugins/linkedin/index.ts
@@ -11,7 +11,7 @@ export type LinkedInLoginScopes = 'r_basicprofile' | 'r_emailaddress' | 'rw_comp
  * Please see the [plugin's repo](https://github.com/zyramedia/cordova-plugin-linkedin#installation) for detailed installation steps.
  *
  * @usage
- * ```
+ * ```typescript
  * import { LinkedIn } from '@ionic-native/linkedin';
  *
  * constructor(private linkedin: LinkedIn) { }

--- a/src/@ionic-native/plugins/location-accuracy/index.ts
+++ b/src/@ionic-native/plugins/location-accuracy/index.ts
@@ -7,7 +7,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * This Cordova/Phonegap plugin for Android and iOS to request enabling/changing of Location Services by triggering a native dialog from within the app, avoiding the need for the user to leave your app to change location settings manually.
  *
  * @usage
- * ```
+ * ```typescript
  * import { LocationAccuracy } from '@ionic-native/location-accuracy';
  *
  * constructor(private locationAccuracy: LocationAccuracy) { }

--- a/src/@ionic-native/plugins/market/index.ts
+++ b/src/@ionic-native/plugins/market/index.ts
@@ -6,7 +6,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * Opens an app's page in the market place (Google Play, App Store)
  *
  * @usage
- * ```
+ * ```typescript
  * import { Market } from '@ionic-native/market';
  *
  * constructor(private market: Market) { }

--- a/src/@ionic-native/plugins/mixpanel/index.ts
+++ b/src/@ionic-native/plugins/mixpanel/index.ts
@@ -9,7 +9,7 @@ declare var mixpanel: any;
  * Cordova Plugin that wraps Mixpanel SDK for Android and iOS
  *
  * @usage
- * ```
+ * ```typescript
  * import { Mixpanel, MixpanelPeople } from '@ionic-native/mixpanel';
  *
  * constructor(private mixpanel: Mixpanel, private mixpanelPeople: MixpanelPeople) { }

--- a/src/@ionic-native/plugins/music-controls/index.ts
+++ b/src/@ionic-native/plugins/music-controls/index.ts
@@ -25,7 +25,7 @@ export interface MusicControlsOptions {
  * Handle also headset event (plug, unplug, headset button).
  *
  * @usage
- * ```
+ * ```typescript
  * import { MusicControls } from '@ionic-native/music-controls';
  *
  * constructor(private musicControls: MusicControls) { }
@@ -115,14 +115,14 @@ export class MusicControls extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  create(options: MusicControlsOptions): Promise<any> {return; }
+  create(options: MusicControlsOptions): Promise<any> { return; }
 
   /**
    * Destroy the media controller
    * @returns {Promise<any>}
    */
   @Cordova()
-  destroy(): Promise<any> {return; }
+  destroy(): Promise<any> { return; }
 
   /**
    * Subscribe to the events of the media controller
@@ -131,25 +131,25 @@ export class MusicControls extends IonicNativePlugin {
   @Cordova({
     observable: true
   })
-  subscribe(): Observable<any> {return; }
+  subscribe(): Observable<any> { return; }
 
   /**
    * Start listening for events, this enables the Observable from the subscribe method
    */
-  @Cordova({sync: true})
-  listen(): void {}
+  @Cordova({ sync: true })
+  listen(): void { }
 
   /**
    * Toggle play/pause:
    * @param isPlaying {boolean}
    */
   @Cordova()
-  updateIsPlaying(isPlaying: boolean): void {}
+  updateIsPlaying(isPlaying: boolean): void { }
 
   /**
    * Toggle dismissable:
    * @param dismissable {boolean}
    */
   @Cordova()
-  updateDismissable(dismissable: boolean): void {}
+  updateDismissable(dismissable: boolean): void { }
 }

--- a/src/@ionic-native/plugins/native-geocoder/index.ts
+++ b/src/@ionic-native/plugins/native-geocoder/index.ts
@@ -16,11 +16,11 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * ...
  *
  * this.nativeGeocoder.reverseGeocode(52.5072095, 13.1452818)
- *   .then((result: NativeGeocoderReverseResult) => console.log("The address is " + result.street + " in " + result.countryCode))
+ *   .then((result: NativeGeocoderReverseResult) => console.log('The address is ' + result.street + ' in ' + result.countryCode))
  *   .catch((error: any) => console.log(error));
  *
- * this.nativeGeocoder.forwardGeocode("Berlin")
- *   .then((coordinates: NativeGeocoderForwardResult) => console.log("The coordinates are latitude=" + coordinates.latitude + " and longitude=" + coordinates.longitude))
+ * this.nativeGeocoder.forwardGeocode('Berlin')
+ *   .then((coordinates: NativeGeocoderForwardResult) => console.log('The coordinates are latitude=' + coordinates.latitude + ' and longitude=' + coordinates.longitude))
  *   .catch((error: any) => console.log(error));
  * ```
  * @interfaces

--- a/src/@ionic-native/plugins/native-page-transitions/index.ts
+++ b/src/@ionic-native/plugins/native-page-transitions/index.ts
@@ -22,7 +22,7 @@ export interface NativeTransitionOptions {
  * The Native Page Transitions plugin uses native hardware acceleration to animate your transitions between views. You have complete control over the type of transition, the duration, and direction.
  *
  * @usage
- * ```
+ * ```typescript
  * import { NativePageTransitions, NativeTransitionOptions } from '@ionic-native/native-page-transitions';
  *
  * constructor(private nativePageTransitions: NativePageTransitions) { }
@@ -91,7 +91,7 @@ export class NativePageTransitions extends IonicNativePlugin {
    * @param options {NativeTransitionOptions} Options for the transition
    * @returns {Promise<any>}
    */
-  @Cordova({platforms: ['iOS', 'Android']})
+  @Cordova({ platforms: ['iOS', 'Android'] })
   fade(options: NativeTransitionOptions): Promise<any> { return; }
 
 
@@ -100,7 +100,7 @@ export class NativePageTransitions extends IonicNativePlugin {
    * @param options {NativeTransitionOptions} Options for the transition
    * @returns {Promise<any>}
    */
-  @Cordova({platforms: ['iOS', 'Android']})
+  @Cordova({ platforms: ['iOS', 'Android'] })
   drawer(options: NativeTransitionOptions): Promise<any> { return; }
 
 
@@ -110,7 +110,7 @@ export class NativePageTransitions extends IonicNativePlugin {
    * @param options {NativeTransitionOptions} Options for the transition
    * @returns {Promise<any>}
    */
-  @Cordova({platforms: ['iOS']})
+  @Cordova({ platforms: ['iOS'] })
   curl(options: NativeTransitionOptions): Promise<any> { return; }
 
   /**

--- a/src/@ionic-native/plugins/native-storage/index.ts
+++ b/src/@ionic-native/plugins/native-storage/index.ts
@@ -43,7 +43,7 @@ export class NativeStorage extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  setItem(reference: string, value: any): Promise<any> {return; }
+  setItem(reference: string, value: any): Promise<any> { return; }
 
   /**
    * Gets a stored item
@@ -51,7 +51,7 @@ export class NativeStorage extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  getItem(reference: string): Promise<any> {return; }
+  getItem(reference: string): Promise<any> { return; }
 
   /**
    * Removes a single stored item
@@ -59,13 +59,13 @@ export class NativeStorage extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  remove(reference: string): Promise<any> {return; }
+  remove(reference: string): Promise<any> { return; }
 
   /**
    * Removes all stored values.
    * @returns {Promise<any>}
    */
   @Cordova()
-  clear(): Promise<any> {return; }
+  clear(): Promise<any> { return; }
 
 }

--- a/src/@ionic-native/plugins/nfc/index.ts
+++ b/src/@ionic-native/plugins/nfc/index.ts
@@ -16,7 +16,7 @@ declare let window: any;
  * This plugin uses NDEF (NFC Data Exchange Format) for maximum compatibilty between NFC devices, tag types, and operating systems.
  *
  * @usage
- * ```
+ * ```typescript
  * import { NFC, Ndef } from '@ionic-native/nfc';
  *
  * constructor(private nfc: NFC, private ndef: Ndef) { }
@@ -34,9 +34,9 @@ declare let window: any;
   pluginRef: 'nfc',
   repo: 'https://github.com/chariotsolutions/phonegap-nfc'
 })
-  /**
-  *@{ NFC } class methods
-  */
+/**
+*@{ NFC } class methods
+*/
 @Injectable()
 export class NFC extends IonicNativePlugin {
   /**
@@ -52,7 +52,7 @@ export class NFC extends IonicNativePlugin {
     clearFunction: 'removeNdefListener',
     clearWithArgs: true
   })
-  addNdefListener(onSuccess?: Function, onFailure?: Function): Observable<any> {return; }
+  addNdefListener(onSuccess?: Function, onFailure?: Function): Observable<any> { return; }
 
   /**
    * Registers an event listener for tags matching any tag type.
@@ -67,7 +67,7 @@ export class NFC extends IonicNativePlugin {
     clearFunction: 'removeTagDiscoveredListener',
     clearWithArgs: true
   })
-  addTagDiscoveredListener(onSuccess?: Function, onFailure?: Function): Observable<any> {return; }
+  addTagDiscoveredListener(onSuccess?: Function, onFailure?: Function): Observable<any> { return; }
 
   /**
    * Registers an event listener for NDEF tags matching a specified MIME type.
@@ -83,7 +83,7 @@ export class NFC extends IonicNativePlugin {
     clearFunction: 'removeMimeTypeListener',
     clearWithArgs: true
   })
-  addMimeTypeListener(mimeType: string, onSuccess?: Function, onFailure?: Function): Observable<any> {return; }
+  addMimeTypeListener(mimeType: string, onSuccess?: Function, onFailure?: Function): Observable<any> { return; }
 
   /**
    * Registers an event listener for formatable NDEF tags.
@@ -96,7 +96,7 @@ export class NFC extends IonicNativePlugin {
     successIndex: 0,
     errorIndex: 3
   })
-  addNdefFormatableListener(onSuccess?: Function, onFailure?: Function): Observable<any> {return; }
+  addNdefFormatableListener(onSuccess?: Function, onFailure?: Function): Observable<any> { return; }
 
   /**
    * Writes an NdefMessage(array of ndef records) to a NFC tag.
@@ -104,13 +104,13 @@ export class NFC extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  write(message: any[]): Promise<any> {return; }
+  write(message: any[]): Promise<any> { return; }
   /**
    * Makes a NFC tag read only. **Warning** this is permanent.
    * @returns {Promise<any>}
    */
   @Cordova()
-  makeReadyOnly(): Promise<any> {return; }
+  makeReadyOnly(): Promise<any> { return; }
 
   /**
    * Shares an NDEF Message(array of ndef records) via peer-to-peer.
@@ -118,20 +118,20 @@ export class NFC extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  share(message: any[]): Promise<any> {return; }
+  share(message: any[]): Promise<any> { return; }
 
   /**
    * Stop sharing NDEF data via peer-to-peer.
    * @returns {Promise<any>}
    */
   @Cordova()
-  unshare(): Promise<any> {return; }
+  unshare(): Promise<any> { return; }
 
   /**
    * Erase a NDEF tag
    */
   @Cordova()
-  erase(): Promise<any> {return; }
+  erase(): Promise<any> { return; }
 
   /**
    * Send a file to another device via NFC handover.
@@ -139,28 +139,28 @@ export class NFC extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  handover(uris: string[]): Promise<any> {return; }
+  handover(uris: string[]): Promise<any> { return; }
 
   /**
    * Stop sharing NDEF data via NFC handover.
    * @returns {Promise<any>}
    */
   @Cordova()
-  stopHandover(): Promise<any> {return; }
+  stopHandover(): Promise<any> { return; }
 
   /**
    * Opens the device's NFC settings.
    * @returns {Promise<any>}
    */
   @Cordova()
-  showSettings(): Promise<any> {return; }
+  showSettings(): Promise<any> { return; }
 
   /**
    * Check if NFC is available and enabled on this device.
    * @returns {Promise<any>}
    */
   @Cordova()
-  enabled(): Promise<any> {return; }
+  enabled(): Promise<any> { return; }
   /**
   * @{ NFC } class utility methods
   * for use with
@@ -171,14 +171,14 @@ export class NFC extends IonicNativePlugin {
    * @returns {string}
    */
   @Cordova({ sync: true })
-  bytesToString(bytes: number[]): string {return; }
+  bytesToString(bytes: number[]): string { return; }
   /**
    * Convert string to byte array.
    * @param str {string}
    * @returns {number[]}
    */
   @Cordova({ sync: true })
-  stringToBytes(str: string): number[] {return; };
+  stringToBytes(str: string): number[] { return; };
   /**
    * Convert byte array to hex string
    *
@@ -186,7 +186,7 @@ export class NFC extends IonicNativePlugin {
    * @returns {string}
    */
   @Cordova({ sync: true })
-  bytesToHexString(bytes: number[]): string {return; };
+  bytesToHexString(bytes: number[]): string { return; };
 
 }
 /**

--- a/src/@ionic-native/plugins/paypal/index.ts
+++ b/src/@ionic-native/plugins/paypal/index.ts
@@ -6,7 +6,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * PayPal plugin for Cordova/Ionic Applications
  *
  * @usage
- * ```
+ * ```typescript
  * import { PayPal, PayPalPayment, PayPalConfiguration } from '@ionic-native/paypal';
  *
  * constructor(private payPal: PayPal) { }
@@ -15,8 +15,8 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  *
  *
  * this.payPal.init({
- *   PayPalEnvironmentProduction: "YOUR_PRODUCTION_CLIENT_ID",
- *   PayPalEnvironmentSandbox: "YOUR_SANDBOX_CLIENT_ID"
+ *   PayPalEnvironmentProduction: 'YOUR_PRODUCTION_CLIENT_ID',
+ *   PayPalEnvironmentSandbox: 'YOUR_SANDBOX_CLIENT_ID'
  * }).then(() => {
  *   // Environments: PayPalEnvironmentNoNetwork, PayPalEnvironmentSandbox, PayPalEnvironmentProduction
  *   this.payPal.prepareToRender('PayPalEnvironmentSandbox', new PayPalConfiguration({
@@ -77,7 +77,7 @@ export class PayPal extends IonicNativePlugin {
    * @returns {Promise<string>}
    */
   @Cordova()
-  version(): Promise<string> {return; }
+  version(): Promise<string> { return; }
 
   /**
    * You must preconnect to PayPal to prepare the device for processing payments.
@@ -89,7 +89,7 @@ export class PayPal extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  init(clientIdsForEnvironments: PayPalEnvironment): Promise<any> {return; }
+  init(clientIdsForEnvironments: PayPalEnvironment): Promise<any> { return; }
 
   /**
    * You must preconnect to PayPal to prepare the device for processing payments.
@@ -101,7 +101,7 @@ export class PayPal extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  prepareToRender(environment: string, configuration: PayPalConfiguration): Promise<any> {return; }
+  prepareToRender(environment: string, configuration: PayPalConfiguration): Promise<any> { return; }
 
   /**
    * Start PayPal UI to collect payment from the user.
@@ -112,7 +112,7 @@ export class PayPal extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  renderSinglePaymentUI(payment: PayPalPayment): Promise<any> {return; }
+  renderSinglePaymentUI(payment: PayPalPayment): Promise<any> { return; }
 
   /**
    * Once a user has consented to future payments, when the user subsequently initiates a PayPal payment
@@ -125,14 +125,14 @@ export class PayPal extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  clientMetadataID(): Promise<any> {return; }
+  clientMetadataID(): Promise<any> { return; }
 
   /**
    * Please Read Docs on Future Payments at https://github.com/paypal/PayPal-iOS-SDK#future-payments
    * @returns {Promise<any>}
    */
   @Cordova()
-  renderFuturePaymentUI(): Promise<any> {return; }
+  renderFuturePaymentUI(): Promise<any> { return; }
 
   /**
    * Please Read Docs on Profile Sharing at https://github.com/paypal/PayPal-iOS-SDK#profile-sharing
@@ -142,7 +142,7 @@ export class PayPal extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  renderProfileSharingUI(scopes: string[]): Promise<any> {return; }
+  renderProfileSharingUI(scopes: string[]): Promise<any> { return; }
 }
 
 export interface PayPalEnvironment {

--- a/src/@ionic-native/plugins/pedometer/index.ts
+++ b/src/@ionic-native/plugins/pedometer/index.ts
@@ -21,7 +21,7 @@ export interface IPedometerData {
  * such as step counts and other information about the distance travelled.
  *
  * @usage
- * ```
+ * ```typescript
  * import { Pedometer } from '@ionic-native/pedometer';
  *
  * Pedometer.isDistanceAvailable()
@@ -69,13 +69,13 @@ export class Pedometer extends IonicNativePlugin {
   @Cordova()
   isFloorCountingAvailable(): Promise<boolean> { return; }
 
-   /**
-   * Starts the delivery of recent pedestrian-related data to your Cordova app.
-   *
-   * When the app is suspended, the delivery of updates stops temporarily.
-   * Upon returning to foreground or background execution, the pedometer object begins updates again.
-   * @return {Observable<IPedometerData>} Returns a Observable that recieves repeatly data from pedometer in background.
-   */
+  /**
+  * Starts the delivery of recent pedestrian-related data to your Cordova app.
+  *
+  * When the app is suspended, the delivery of updates stops temporarily.
+  * Upon returning to foreground or background execution, the pedometer object begins updates again.
+  * @return {Observable<IPedometerData>} Returns a Observable that recieves repeatly data from pedometer in background.
+  */
   @Cordova({
     observable: true,
     clearFunction: 'stopPedometerUpdates'

--- a/src/@ionic-native/plugins/photo-library/index.ts
+++ b/src/@ionic-native/plugins/photo-library/index.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@angular/core';
  * cdvphotolibrary urls should be trusted by Angular. See plugin homepage to learn how.
  *
  * @usage
- * ```
+ * ```typescript
  * import { PhotoLibrary } from '@ionic-native/photo-library';
  *
  * constructor(private photoLibrary: PhotoLibrary) { }
@@ -32,10 +32,10 @@ import { Injectable } from '@angular/core';
  *       });
  *     },
  *     error: err => {},
- *     complete: () => { console.log("could not get photos"); }
+ *     complete: () => { console.log('could not get photos'); }
  *   });
  * })
- * .catch(err => console.log("permissions weren't granted"));
+ * .catch(err => console.log('permissions weren't granted'));
  *
  * ```
  */
@@ -57,8 +57,8 @@ export class PhotoLibrary extends IonicNativePlugin {
    */
   @CordovaFiniteObservable({
     callbackOrder: 'reverse',
-    resultFinalPredicate: (result: {isLastChunk: boolean}) => { return result.isLastChunk; },
-    resultTransform: (result: {library: LibraryItem[]}) => { return result.library; },
+    resultFinalPredicate: (result: { isLastChunk: boolean }) => { return result.isLastChunk; },
+    resultTransform: (result: { library: LibraryItem[] }) => { return result.library; },
   })
   getLibrary(options?: GetLibraryOptions): Observable<LibraryItem[]> { return; }
 

--- a/src/@ionic-native/plugins/pinterest/index.ts
+++ b/src/@ionic-native/plugins/pinterest/index.ts
@@ -133,7 +133,7 @@ export interface PinterestPin {
  * Cordova plugin for Pinterest
  *
  * @usage
- * ```
+ * ```typescript
  * import { Pinterest, PinterestUser, PinterestPin, PinterestBoard } from '@ionic-native/pinterest';
  *
  * constructor(private pinterest: Pinterest) { }

--- a/src/@ionic-native/plugins/power-management/index.ts
+++ b/src/@ionic-native/plugins/power-management/index.ts
@@ -7,7 +7,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * It should be used for applications which keep running for a long time without any user interaction.
  *
  * @usage
- * ```
+ * ```typescript
  * import { PowerManagement } from '@ionic-native/power-management';
  *
  * constructor(private powerManagement: PowerManagement) { }
@@ -33,21 +33,21 @@ export class PowerManagement extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  acquire(): Promise<any> {return; }
+  acquire(): Promise<any> { return; }
 
   /**
    * This acquires a partial wakelock, allowing the screen to be dimmed.
    * @returns {Promise<any>}
    */
   @Cordova()
-  dim(): Promise<any> {return; }
+  dim(): Promise<any> { return; }
 
   /**
    * Release the wakelock. It's important to do this when you're finished with the wakelock, to avoid unnecessary battery drain.
    * @returns {Promise<any>}
    */
   @Cordova()
-  release(): Promise<any> {return; }
+  release(): Promise<any> { return; }
 
   /**
    * By default, the plugin will automatically release a wakelock when your app is paused (e.g. when the screen is turned off, or the user switches to another app).
@@ -56,5 +56,5 @@ export class PowerManagement extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  setReleaseOnPause(set: boolean): Promise<any> {return; }
+  setReleaseOnPause(set: boolean): Promise<any> { return; }
 }

--- a/src/@ionic-native/plugins/rollbar/index.ts
+++ b/src/@ionic-native/plugins/rollbar/index.ts
@@ -8,7 +8,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * This plugin adds Rollbar App monitoring to your application
  *
  * @usage
- * ```
+ * ```typescript
  * import { Rollbar } from '@ionic-native/rollbar';
  *
  * constructor(private rollbar: Rollbar) { }

--- a/src/@ionic-native/plugins/safari-view-controller/index.ts
+++ b/src/@ionic-native/plugins/safari-view-controller/index.ts
@@ -16,7 +16,7 @@ export interface SafariViewControllerOptions {
  * @name Safari View Controller
  * @description
  * @usage
- * ```
+ * ```typescript
  * import { SafariViewController } from '@ionic-native/safari-view-controller';
  *
  * constructor(private safariViewController: SafariViewController) { }

--- a/src/@ionic-native/plugins/secure-storage/index.ts
+++ b/src/@ionic-native/plugins/secure-storage/index.ts
@@ -8,7 +8,7 @@ declare var cordova: any;
  */
 export class SecureStorageObject {
 
-  constructor(private _objectInstance?: any) {}
+  constructor(private _objectInstance?: any) { }
 
   /**
    * Gets a stored item

--- a/src/@ionic-native/plugins/serial/index.ts
+++ b/src/@ionic-native/plugins/serial/index.ts
@@ -20,8 +20,7 @@ export interface SerialOpenOptions {
  * This plugin provides functions for working with Serial connections
  *
  * @usage
- *
- * ```
+ * ```typescript
  * import { Serial } from '@ionic-native/serial';
  *
  * constructor(private serial: Serial) { }

--- a/src/@ionic-native/plugins/shake/index.ts
+++ b/src/@ionic-native/plugins/shake/index.ts
@@ -38,6 +38,6 @@ export class Shake extends IonicNativePlugin {
     successIndex: 0,
     errorIndex: 2
   })
-  startWatch(sensitivity?: number): Observable<any> {return; }
+  startWatch(sensitivity?: number): Observable<any> { return; }
 
 }

--- a/src/@ionic-native/plugins/sms/index.ts
+++ b/src/@ionic-native/plugins/sms/index.ts
@@ -73,7 +73,7 @@ export class SMS extends IonicNativePlugin {
     phoneNumber: string | string[],
     message: string,
     options?: SmsOptions
-  ): Promise<any> { return; }
+    ): Promise<any> { return; }
 
   /**
    * This function lets you know if the app has permission to send SMS

--- a/src/@ionic-native/plugins/social-sharing/index.ts
+++ b/src/@ionic-native/plugins/social-sharing/index.ts
@@ -47,7 +47,7 @@ export class SocialSharing extends IonicNativePlugin {
    * @returns {Promise<any>}
    */
   @Cordova()
-  share(message?: string, subject?: string, file?: string|string[], url?: string): Promise<any> { return; }
+  share(message?: string, subject?: string, file?: string | string[], url?: string): Promise<any> { return; }
 
   /**
    * Shares using the share sheet with additional options and returns a result object or an error message (requires plugin version 5.1.0+)
@@ -57,7 +57,7 @@ export class SocialSharing extends IonicNativePlugin {
   @Cordova({
     platforms: ['iOS', 'Android']
   })
-  shareWithOptions(options: { message?: string, subject?: string, files?: string|string[], url?: string, chooserTitle?: string }): Promise<any> { return; }
+  shareWithOptions(options: { message?: string, subject?: string, files?: string | string[], url?: string, chooserTitle?: string }): Promise<any> { return; }
 
   /**
    * Checks if you can share via a specific app.
@@ -194,7 +194,7 @@ export class SocialSharing extends IonicNativePlugin {
     successIndex: 6,
     errorIndex: 7
   })
-  shareViaEmail(message: string, subject: string, to: string[], cc?: string[], bcc?: string[], files?: string|string[]): Promise<any> { return; }
+  shareViaEmail(message: string, subject: string, to: string[], cc?: string[], bcc?: string[], files?: string | string[]): Promise<any> { return; }
 
   /**
    * Share via AppName

--- a/src/@ionic-native/plugins/speech-recognition/index.ts
+++ b/src/@ionic-native/plugins/speech-recognition/index.ts
@@ -50,7 +50,7 @@ export interface SpeechRecognitionListeningOptionsAndroid {
  * This plugin does speech recognition using cloud services
  *
  * @usage
- * ```
+ * ```typescript
  * import { SpeechRecognition } from '@ionic-native/speech-recognition';
  *
  * constructor(private speechRecognition: SpeechRecognition) { }

--- a/src/@ionic-native/plugins/spinner-dialog/index.ts
+++ b/src/@ionic-native/plugins/spinner-dialog/index.ts
@@ -46,7 +46,7 @@ export class SpinnerDialog extends IonicNativePlugin {
   @Cordova({
     sync: true
   })
-  show(title?: string, message?: string, cancelCallback?: any, iOSOptions?: SpinnerDialogIOSOptions): void {}
+  show(title?: string, message?: string, cancelCallback?: any, iOSOptions?: SpinnerDialogIOSOptions): void { }
 
   /**
    * Hides the spinner dialog if visible
@@ -54,6 +54,6 @@ export class SpinnerDialog extends IonicNativePlugin {
   @Cordova({
     sync: true
   })
-  hide(): void {}
+  hide(): void { }
 
 }

--- a/src/@ionic-native/plugins/splash-screen/index.ts
+++ b/src/@ionic-native/plugins/splash-screen/index.ts
@@ -33,7 +33,7 @@ export class SplashScreen extends IonicNativePlugin {
   @Cordova({
     sync: true
   })
-  show(): void {}
+  show(): void { }
 
   /**
    * Hides the splashscreen
@@ -41,6 +41,6 @@ export class SplashScreen extends IonicNativePlugin {
   @Cordova({
     sync: true
   })
-  hide(): void {}
+  hide(): void { }
 
 }

--- a/src/@ionic-native/plugins/sqlite-porter/index.ts
+++ b/src/@ionic-native/plugins/sqlite-porter/index.ts
@@ -7,7 +7,7 @@ import { Injectable } from '@angular/core';
  * This Cordova/Phonegap plugin can be used to import/export to/from a SQLite database using either SQL or JSON.
  *
  * @usage
- * ```
+ * ```typescript
  * import { SQLitePorter } from '@ionic-native/sqlite-porter';
  *
  *
@@ -15,7 +15,7 @@ import { Injectable } from '@angular/core';
  *
  * ...
  *
- * let db = window.openDatabase("Test", "1.0", "TestDB", 1 * 1024);
+ * let db = window.openDatabase('Test', '1.0', 'TestDB', 1 * 1024);
  * // or we can use SQLite plugin
  * // we will assume that we injected SQLite into this component as sqlite
  * this.sqlite.create({
@@ -28,8 +28,8 @@ import { Injectable } from '@angular/core';
  *   });
  *
  *
- * let sql = "CREATE TABLE Artist ([Id] PRIMARY KEY, [Title]);" +
- *            "INSERT INTO Artist(Id,Title) VALUES ('1','Fred');";
+ * let sql = 'CREATE TABLE Artist ([Id] PRIMARY KEY, [Title]);' +
+ *            'INSERT INTO Artist(Id,Title) VALUES ("1","Fred");';
  *
  * this.sqlitePorter.importSqlToDb(db, sql)
  *   .then(() => console.log('Imported'))

--- a/src/@ionic-native/plugins/sqlite/index.ts
+++ b/src/@ionic-native/plugins/sqlite/index.ts
@@ -198,7 +198,7 @@ export class SQLite extends IonicNativePlugin {
   @CordovaCheck()
   create(config: SQLiteDatabaseConfig): Promise<SQLiteObject> {
     return new Promise((resolve, reject) => {
-        sqlitePlugin.openDatabase(config, db => resolve(new SQLiteObject(db)), reject);
+      sqlitePlugin.openDatabase(config, db => resolve(new SQLiteObject(db)), reject);
     });
   }
 

--- a/src/@ionic-native/plugins/stepcounter/index.ts
+++ b/src/@ionic-native/plugins/stepcounter/index.ts
@@ -10,7 +10,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * - read device's stepcounter data
  *
  * @usage
- * ```
+ * ```typescript
  * import { Stepcounter } from '@ionic-native/stepcounter';
  *
  * constructor(private stepcounter: Stepcounter) { }

--- a/src/@ionic-native/plugins/streaming-media/index.ts
+++ b/src/@ionic-native/plugins/streaming-media/index.ts
@@ -22,7 +22,7 @@ export interface StreamingAudioOptions {
  * This plugin allows you to stream audio and video in a fullscreen, native player on iOS and Android.
  *
  * @usage
- * ```
+ * ```typescript
  * import { StreamingMedia, StreamingVideoOptions } from '@ionic-native/streaming-media';
  *
  * constructor(private streamingMedia: StreamingMedia) { }
@@ -54,7 +54,7 @@ export class StreamingMedia extends IonicNativePlugin {
    * @param videoUrl {string} The URL of the video
    * @param options {StreamingVideoOptions} Options
    */
-  @Cordova({sync: true})
+  @Cordova({ sync: true })
   playVideo(videoUrl: string, options?: StreamingVideoOptions): void { }
 
   /**
@@ -62,25 +62,25 @@ export class StreamingMedia extends IonicNativePlugin {
    * @param audioUrl {string} The URL of the audio stream
    * @param options {StreamingAudioOptions} Options
    */
-  @Cordova({sync: true})
+  @Cordova({ sync: true })
   playAudio(audioUrl: string, options?: StreamingAudioOptions): void { }
 
   /**
    * Stops streaming audio
    */
-  @Cordova({sync: true})
+  @Cordova({ sync: true })
   stopAudio(): void { }
 
   /**
    * Pauses streaming audio
    */
-  @Cordova({sync: true, platforms: ['iOS']})
+  @Cordova({ sync: true, platforms: ['iOS'] })
   pauseAudio(): void { }
 
   /**
    * Resumes streaming audio
    */
-  @Cordova({sync: true, platforms: ['iOS']})
+  @Cordova({ sync: true, platforms: ['iOS'] })
   resumeAudio(): void { }
 
 }

--- a/src/@ionic-native/plugins/stripe/index.ts
+++ b/src/@ionic-native/plugins/stripe/index.ts
@@ -85,7 +85,7 @@ export interface StripeBankAccountParams {
  * A plugin that allows you to use Stripe's Native SDKs for Android and iOS.
  *
  * @usage
- * ```
+ * ```typescript
  * import { Stripe } from '@ionic-native/stripe';
  *
  * constructor(private stripe: Stripe) { }

--- a/src/@ionic-native/plugins/taptic-engine/index.ts
+++ b/src/@ionic-native/plugins/taptic-engine/index.ts
@@ -7,7 +7,7 @@ import { Injectable } from '@angular/core';
  * An Ionic plugin to use Taptic Engine API on iPHone 7, 7 Plus or newer.
  *
  * @usage
- * ```ts
+ * ```typescript
  * import { TapticEngine } from '@ionic-native/taptic-engine';
  *
  * ...

--- a/src/@ionic-native/plugins/text-to-speech/index.ts
+++ b/src/@ionic-native/plugins/text-to-speech/index.ts
@@ -2,12 +2,12 @@ import { Injectable } from '@angular/core';
 import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
 
 export interface TTSOptions {
-    /** text to speak */
-    text: string;
-    /** a string like 'en-US', 'zh-CN', etc */
-    locale?: string;
-    /** speed rate, 0 ~ 1 */
-    rate?: number;
+  /** text to speak */
+  text: string;
+  /** a string like 'en-US', 'zh-CN', etc */
+  locale?: string;
+  /** speed rate, 0 ~ 1 */
+  rate?: number;
 }
 
 /**
@@ -16,7 +16,7 @@ export interface TTSOptions {
  * Text to Speech plugin
  *
  * @usage
- * ```
+ * ```typescript
  * import { TextToSpeech } from '@ionic-native/text-to-speech';
  *
  * constructor(private tts: TextToSpeech) { }

--- a/src/@ionic-native/plugins/themeable-browser/index.ts
+++ b/src/@ionic-native/plugins/themeable-browser/index.ts
@@ -87,13 +87,13 @@ export class ThemeableBrowserObject {
    * Displays an browser window that was opened hidden. Calling this has no effect
    * if the browser was already visible.
    */
-  @CordovaInstance({sync: true})
+  @CordovaInstance({ sync: true })
   show(): void { }
 
   /**
    * Closes the browser window.
    */
-  @CordovaInstance({sync: true})
+  @CordovaInstance({ sync: true })
   close(): void { }
 
   /**
@@ -108,7 +108,7 @@ export class ThemeableBrowserObject {
    * @returns {Promise<any>}
    */
   @CordovaInstance()
-  executeScript(script: {file?: string, code?: string}): Promise<any> {return; }
+  executeScript(script: { file?: string, code?: string }): Promise<any> { return; }
 
   /**
    * Injects CSS into the browser window.
@@ -116,7 +116,7 @@ export class ThemeableBrowserObject {
    * @returns {Promise<any>}
    */
   @CordovaInstance()
-  insertCss(css: {file?: string, code?: string}): Promise<any> {return; }
+  insertCss(css: { file?: string, code?: string }): Promise<any> { return; }
 
   /**
    * A method that allows you to listen to events happening in the browser.
@@ -140,7 +140,7 @@ export class ThemeableBrowserObject {
  * In-app browser that allows styling.
  *
  * @usage
- * ```
+ * ```typescript
  * import { ThemeableBrowser, ThemeableBrowserOptions, ThemeableBrowserObject } from '@ionic-native/themeable-browser';
  *
  * constructor(private themeableBrowser: ThemeableBrowser) { }

--- a/src/@ionic-native/plugins/three-dee-touch/index.ts
+++ b/src/@ionic-native/plugins/three-dee-touch/index.ts
@@ -63,22 +63,22 @@ export interface ThreeDeeTouchForceTouch {
  * @description
  * @usage
  * Please do refer to the original plugin's repo for detailed usage. The usage example here might not be sufficient.
- * ```
+ * ```typescript
  * import { ThreeDeeTouch, ThreeDeeTouchQuickAction, ThreeDeeTouchForceTouch } from '@ionic-native/three-dee-touch';
  *
  * constructor(private threeDeeTouch: ThreeDeeTouch) { }
  *
  * ...
  *
- * this.threeDeeTouch.isAvailable().then(isAvailable => console.log("3D Touch available? " + isAvailable));
+ * this.threeDeeTouch.isAvailable().then(isAvailable => console.log('3D Touch available? ' + isAvailable));
  *
  * this.threeDeeTouch.watchForceTouches()
  *   .subscribe(
  *     (data: ThreeDeeTouchForceTouch) => {
- *       console.log("Force touch %" + data.force);
- *       console.log("Force touch timestamp: " + data.timestamp);
- *       console.log("Force touch x: " + data.x);
- *       console.log("Force touch y: " + data.y);
+ *       console.log('Force touch %' + data.force);
+ *       console.log('Force touch timestamp: ' + data.timestamp);
+ *       console.log('Force touch x: ' + data.x);
+ *       console.log('Force touch y: ' + data.y);
  *     }
  *   );
  *

--- a/src/@ionic-native/plugins/toast/index.ts
+++ b/src/@ionic-native/plugins/toast/index.ts
@@ -51,7 +51,7 @@ export interface ToastOptions {
  *
  * ...
  *
- * this.toast.show("I'm a toast", '5000', 'center').subscribe(
+ * this.toast.show('I'm a toast', '5000', 'center').subscribe(
  *   toast => {
  *     console.log(toast);
  *   }

--- a/src/@ionic-native/plugins/twitter-connect/index.ts
+++ b/src/@ionic-native/plugins/twitter-connect/index.ts
@@ -66,18 +66,18 @@ export class TwitterConnect extends IonicNativePlugin {
    * @returns {Promise<TwitterConnectResponse>} returns a promise that resolves if logged in and rejects if failed to login
    */
   @Cordova()
-  login(): Promise<TwitterConnectResponse> {return; }
+  login(): Promise<TwitterConnectResponse> { return; }
   /**
    * Logs out
    * @returns {Promise<any>} returns a promise that resolves if logged out and rejects if failed to logout
    */
   @Cordova()
-  logout(): Promise<any> {return; }
+  logout(): Promise<any> { return; }
 
   /**
    * Returns user's profile information
    * @returns {Promise<any>} returns a promise that resolves if user profile is successfully retrieved and rejects if request fails
    */
   @Cordova()
-  showUser(): Promise<any> {return; }
+  showUser(): Promise<any> { return; }
 }

--- a/src/@ionic-native/plugins/unique-device-id/index.ts
+++ b/src/@ionic-native/plugins/unique-device-id/index.ts
@@ -7,7 +7,7 @@ import { Injectable } from '@angular/core';
  * This plugin produces a unique, cross-install, app-specific device id.
  *
  * @usage
- * ```
+ * ```typescript
  * import { UniqueDeviceID } from '@ionic-native/unique-device-id';
  *
  * constructor(private uniqueDeviceID: UniqueDeviceID) { }

--- a/src/@ionic-native/plugins/video-editor/index.ts
+++ b/src/@ionic-native/plugins/video-editor/index.ts
@@ -124,7 +124,7 @@ export interface VideoInfo {
  * @description Edit videos using native device APIs
  *
  * @usage
- * ```
+ * ```typescript
  * import { VideoEditor } from '@ionic-native/video-editor';
  *
  * constructor(private videoEditor: VideoEditor) { }

--- a/src/@ionic-native/plugins/video-player/index.ts
+++ b/src/@ionic-native/plugins/video-player/index.ts
@@ -5,10 +5,10 @@ import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
  * Options for the video playback using the `play` function.
  */
 export interface VideoOptions {
-    /**
-   * Set the initial volume of the video playback, where 0.0 is 0% volume and 1.0 is 100%.
-   * For example: for a volume of 30% set the value to 0.3.
-   */
+  /**
+ * Set the initial volume of the video playback, where 0.0 is 0% volume and 1.0 is 100%.
+ * For example: for a volume of 30% set the value to 0.3.
+ */
   volume?: number;
   /**
    * There are to options for the scaling mode. SCALE_TO_FIT which is default and SCALE_TO_FIT_WITH_CROPPING.
@@ -33,7 +33,7 @@ export interface VideoOptions {
  * ...
  *
  * // Playing a video.
- * this.videoPlayer.play("file:///android_asset/www/movie.mp4").then(() => {
+ * this.videoPlayer.play('file:///android_asset/www/movie.mp4').then(() => {
  *  console.log('video completed');
  * }).catch(err => {
  *  console.log(err);

--- a/src/@ionic-native/plugins/youtube-video-player/index.ts
+++ b/src/@ionic-native/plugins/youtube-video-player/index.ts
@@ -6,7 +6,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * Plays YouTube videos in Native YouTube App
  *
  * @usage
- * ```
+ * ```typescript
  * import { YoutubeVideoPlayer } from '@ionic-native/youtube-video-player';
  *
  * constructor(private youtube: YoutubeVideoPlayer) { }
@@ -31,6 +31,6 @@ export class YoutubeVideoPlayer extends IonicNativePlugin {
    * Plays a YouTube video
    * @param videoId {string} Video ID
    */
-  @Cordova({sync: true})
+  @Cordova({ sync: true })
   openVideo(videoId: string): void { }
 }

--- a/src/@ionic-native/plugins/zbar/index.ts
+++ b/src/@ionic-native/plugins/zbar/index.ts
@@ -43,7 +43,7 @@ export interface ZBarOptions {
  * Requires Cordova plugin: `cordova-plugin-cszbar`. For more info, please see the [zBar plugin docs](https://github.com/tjwoon/csZBar).
  *
  * @usage
- * ```
+ * ```typescript
  * import { ZBar, ZBarOptions } from '@ionic-native/z-bar';
  *
  * constructor(private zbar: ZBar) { }
@@ -51,7 +51,7 @@ export interface ZBarOptions {
  * ...
  *
  * let ZBarOptions = {
- *       flash: "off",
+ *       flash: 'off',
  *       drawSight: false
  *     };
  *

--- a/src/@ionic-native/plugins/zip/index.ts
+++ b/src/@ionic-native/plugins/zip/index.ts
@@ -7,7 +7,7 @@ import { Plugin, Cordova, IonicNativePlugin } from '@ionic-native/core';
  * A Cordova plugin to unzip files in Android and iOS.
  *
  * @usage
- * ```
+ * ```typescript
  * import { Zip } from '@ionic-native/zip';
  *
  * constructor(private zip: Zip) { }
@@ -42,6 +42,6 @@ export class Zip extends IonicNativePlugin {
     successIndex: 2,
     errorIndex: 4
   })
-  unzip(sourceZip: string, destUrl: string, onProgress?: Function): Promise<number> {return; }
+  unzip(sourceZip: string, destUrl: string, onProgress?: Function): Promise<number> { return; }
 
 }


### PR DESCRIPTION
I know it looks like many changes, but I haven't changed that much.

- In some plugin usage parts, the "typescript" markup was missing.
- I also unified the console.log strings from console.log("hello") to console.log('Hello') so any plugin page look the same.
- And I lint some plugins. 