### PR TITLE
docs(admob): improved example

### DIFF
--- a/src/@ionic-native/plugins/admob/index.ts
+++ b/src/@ionic-native/plugins/admob/index.ts
@@ -96,8 +96,9 @@ export interface AdExtras {
  * @usage
  * ```typescript
  * import { AdMob } from '@ionic-native/admob';
+ * import { Platform } from 'ionic-angular';
  *
- * constructor(private admob: AdMob) { }
+ * constructor(private admob: AdMob, private platform: Platform ) { }
  *
  * ionViewDidLoad() {
  *   this.admob.onAdDismiss()
@@ -105,7 +106,13 @@ export interface AdExtras {
  * }
  *
  * onClick() {
- *   this.admob.prepareInterstitial('YOUR_ADID')
+ *   let adId;
+ *   if(this.platform.is('android') {
+ *     adId = 'YOUR_ADID_ANDROID';
+ *   } else if (this.platform.is('ios')) {
+ *     adId = 'YOUR_ADID_IOS';
+ *   }
+ *   this.admob.prepareInterstitial(adId)
  *     .then(() => { this.admob.showInterstitial(); });
  * }
  *


### PR DESCRIPTION
Because the Admob ad id differs according to the platform I imported the Platform to check the platform.