### PR TITLE
docs(apprate): update example

### DIFF
--- a/src/@ionic-native/plugins/app-rate/index.ts
+++ b/src/@ionic-native/plugins/app-rate/index.ts
@@ -113,9 +113,9 @@ export interface AppUrls {
  *
  * this.appRate.preferences.storeAppURL = {
  *   usesUntilPrompt: 3,
- *   ios: '<my_app_id>',
+ *   ios: '<app_id>',
  *   android: 'market://details?id=<package_name>',
- *   windows: 'ms-windows-store://review/?ProductId=<Store_ID>'
+ *   windows: 'ms-windows-store://review/?ProductId=<store_ID>'
  * };
  *
  * this.appRate.promptForRating(false);

--- a/src/@ionic-native/plugins/app-rate/index.ts
+++ b/src/@ionic-native/plugins/app-rate/index.ts
@@ -111,12 +111,12 @@ export interface AppUrls {
  *
  * ...
  *
- *  this.appRate.preferences.storeAppURL = {
- *    usesUntilPrompt: 3,
- *    ios: '<my_app_id>',
- *    android: 'market://details?id=<package_name>',
- *    windows: 'ms-windows-store://review/?ProductId=<Store_ID>'
- *  };
+ * this.appRate.preferences.storeAppURL = {
+ *   usesUntilPrompt: 3,
+ *   ios: '<my_app_id>',
+ *   android: 'market://details?id=<package_name>',
+ *   windows: 'ms-windows-store://review/?ProductId=<Store_ID>'
+ * };
  *
  * this.appRate.promptForRating(false);
  * ```

--- a/src/@ionic-native/plugins/app-rate/index.ts
+++ b/src/@ionic-native/plugins/app-rate/index.ts
@@ -110,13 +110,22 @@ export interface AppUrls {
  * constructor(private appRate: AppRate) { }
  *
  * ...
+ * // set certain preferences
+ * this.appRate.preferences.storeAppURL = {
+ *   ios: '<app_id>',
+ *   android: 'market://details?id=<package_name>',
+ *   windows: 'ms-windows-store://review/?ProductId=<store_id>'
+ * };
  *
+ * this.appRate.promptForRating(true);
+ *
+ * // or, override the whole preferences object
  * this.appRate.preferences = {
  *   usesUntilPrompt: 3,
  *   storeAppURL: {
  *    ios: '<app_id>',
  *    android: 'market://details?id=<package_name>',
- *    windows: 'ms-windows-store://review/?ProductId=<store_ID>'
+ *    windows: 'ms-windows-store://review/?ProductId=<store_id>'
  *   }
  * };
  *

--- a/src/@ionic-native/plugins/app-rate/index.ts
+++ b/src/@ionic-native/plugins/app-rate/index.ts
@@ -112,6 +112,7 @@ export interface AppUrls {
  * ...
  *
  *  this.appRate.preferences.storeAppURL = {
+ *    usesUntilPrompt: 3,
  *    ios: '<my_app_id>',
  *    android: 'market://details?id=<package_name>',
  *    windows: 'ms-windows-store://review/?ProductId=<Store_ID>'

--- a/src/@ionic-native/plugins/app-rate/index.ts
+++ b/src/@ionic-native/plugins/app-rate/index.ts
@@ -111,11 +111,13 @@ export interface AppUrls {
  *
  * ...
  *
- * this.appRate.preferences.storeAppURL = {
+ * this.appRate.preferences = {
  *   usesUntilPrompt: 3,
- *   ios: '<app_id>',
- *   android: 'market://details?id=<package_name>',
- *   windows: 'ms-windows-store://review/?ProductId=<store_ID>'
+ *   storeAppURL: {
+ *    ios: '<app_id>',
+ *    android: 'market://details?id=<package_name>',
+ *    windows: 'ms-windows-store://review/?ProductId=<store_ID>'
+ *   }
  * };
  *
  * this.appRate.promptForRating(false);


### PR DESCRIPTION
Because in the example the parameter for the promptForRating() method is false, the user has to set the usesUntilPrompt option otherwise the app rate prompt will never be shown.