### PR TITLE
docs(app preferences): unified example

### DIFF
--- a/src/@ionic-native/plugins/app-preferences/index.ts
+++ b/src/@ionic-native/plugins/app-preferences/index.ts
@@ -11,11 +11,12 @@ import { Injectable } from '@angular/core';
  * ```typescript
  * import { AppPreferences } from '@ionic-native/app-preferences';
  *
- * constructor(private appPreferences: AppPreferences) {
+ * constructor(private appPreferences: AppPreferences) { }
  *
- *   this.appPreferences.fetch('key').then((res) => { console.log(res); });
+ * ...
  *
- * }
+ * this.appPreferences.fetch('key').then((res) => { console.log(res); });
+ *
  * ```
  *
  */


### PR DESCRIPTION
I changed the usage part to match the usage part of other plugins 

1. constructor with the private import
2. Call the plugin methods