### PR TITLE
docs(google-maps): example fix #1444

### DIFF
--- a/src/@ionic-native/plugins/google-maps/index.ts
+++ b/src/@ionic-native/plugins/google-maps/index.ts
@@ -403,7 +403,12 @@ export class GoogleMap {
  *
  *  // listen to MAP_READY event
  *  // You must wait for this event to fire before adding something to the map or modifying it in anyway
- *  map.one(GoogleMapsEvent.MAP_READY).then(() => console.log('Map is ready!'));
+ *  map.one(GoogleMapsEvent.MAP_READY).then(
+ *    () => {
+ *      console.log('Map is ready!');
+ *      // Now you can add elements to the map like the marker
+ *    }
+ *  );
  *
  *  // create LatLng object
  *  let ionic: LatLng = new LatLng(43.0741904,-89.3809802);


### PR DESCRIPTION
It should be clearer now that the marker etc. should be added inside the .then() block

Related to: 
- https://github.com/driftyco/ionic-native/issues/1444
- https://forum.ionicframework.com/t/ionic-build-android-failed/88742/9