### PR TITLE
docs(template): Improved plugin docs

### DIFF
--- a/scripts/docs/templates/common.template.html
+++ b/scripts/docs/templates/common.template.html
@@ -61,7 +61,7 @@ docType: "<$ doc.docType $>"
   <tr>
     <td>
       <$ param.name $>
-      <@- if param.alias @>| <$ param.alias $><@ endif -@>f
+      <@- if param.alias @>| <$ param.alias $><@ endif -@>
     </td>
     <td>
       <$ typeList(param.typeList) $>

--- a/scripts/docs/templates/common.template.html
+++ b/scripts/docs/templates/common.template.html
@@ -61,7 +61,7 @@ docType: "<$ doc.docType $>"
   <tr>
     <td>
       <$ param.name $>
-      <@- if param.alias @>| <$ param.alias $><@ endif -@>
+      <@- if param.alias @>| <$ param.alias $><@ endif -@>f
     </td>
     <td>
       <$ typeList(param.typeList) $>
@@ -165,6 +165,7 @@ docType: "<$ doc.docType $>"
 <@ endif @>
 
 <# --- Install commands --- #>
+<h2>Installation</h2>
 <pre><code class="nohighlight">$ <@ if prop.install @><$ prop.install $><@ else @>ionic plugin add --save <$ prop.plugin $><@ endif @>
 $ npm install --save @ionic-native/<$ doc.npmId $>
 </code></pre>

--- a/scripts/docs/templates/common.template.html
+++ b/scripts/docs/templates/common.template.html
@@ -177,7 +177,7 @@ docType: "<$ doc.docType $>"
 <h2>Installation</h2>
 <ol class="installation">
   <li>Install the Cordova and Ionic Native plugins:<br>
-    <pre><code class="nohighlight">$ <@ if prop.install @><$ prop.install $><@ else @>ionic plugin add --save <$ prop.plugin $><@ endif @>
+    <pre><code class="nohighlight">$ <@ if prop.install @><$ prop.install $><@ else @>ionic cordova plugin add --save <$ prop.plugin $><@ endif @>
 $ npm install --save @ionic-native/<$ doc.npmId $>
 </code></pre>
   </li>

--- a/scripts/docs/templates/common.template.html
+++ b/scripts/docs/templates/common.template.html
@@ -164,19 +164,20 @@ docType: "<$ doc.docType $>"
 </p>
 <@ endif @>
 
-<# --- Install commands --- #>
-<h2>Installation</h2>
-<pre><code class="nohighlight">$ <@ if prop.install @><$ prop.install $><@ else @>ionic plugin add --save <$ prop.plugin $><@ endif @>
-$ npm install --save @ionic-native/<$ doc.npmId $>
-</code></pre>
+<# --- Plugin description --- #>
+<$ doc.description | marked $>
+
 <p>Repo:
   <a href="<$ prop.repo $>">
     <$ prop.repo $>
   </a>
 </p>
 
-<# --- Plugin description --- #>
-<$ doc.description | marked $>
+<# --- Install commands --- #>
+<h2>Installation</h2>
+<pre><code class="nohighlight">$ <@ if prop.install @><$ prop.install $><@ else @>ionic plugin add --save <$ prop.plugin $><@ endif @>
+$ npm install --save @ionic-native/<$ doc.npmId $>
+</code></pre>
 
 <# --- Plugin supported platforms --- #>
 <@ if prop.platforms @>

--- a/scripts/docs/templates/common.template.html
+++ b/scripts/docs/templates/common.template.html
@@ -175,15 +175,6 @@ docType: "<$ doc.docType $>"
 
 <# --- Install commands --- #>
 <h2>Installation</h2>
-<style>
-  .installation li {
-    font-size:15px;
-    margin-bottom:10px;
-  }
-  .installation li pre {
-    margin-top:10px;
-  }
-</style>
 <ol class="installation">
   <li>Install the Cordova and Ionic Native plugins:<br>
     <pre><code class="nohighlight">$ <@ if prop.install @><$ prop.install $><@ else @>ionic plugin add --save <$ prop.plugin $><@ endif @>

--- a/scripts/docs/templates/common.template.html
+++ b/scripts/docs/templates/common.template.html
@@ -175,9 +175,18 @@ docType: "<$ doc.docType $>"
 
 <# --- Install commands --- #>
 <h2>Installation</h2>
-<ol>
-  <li style="font-size:15px; margin-bottom:10px;">Install the Cordova and Ionic Native plugins:<br>
-    <pre style="margin-top:10px;"><code class="nohighlight">$ <@ if prop.install @><$ prop.install $><@ else @>ionic plugin add --save <$ prop.plugin $><@ endif @>
+<style>
+  .installation li {
+    font-size:15px;
+    margin-bottom:10px;
+  }
+  .installation li pre {
+    margin-top:10px;
+  }
+</style>
+<ol class="installation">
+  <li>Install the Cordova and Ionic Native plugins:<br>
+    <pre><code class="nohighlight">$ <@ if prop.install @><$ prop.install $><@ else @>ionic plugin add --save <$ prop.plugin $><@ endif @>
 $ npm install --save @ionic-native/<$ doc.npmId $>
 </code></pre>
   </li>

--- a/scripts/docs/templates/common.template.html
+++ b/scripts/docs/templates/common.template.html
@@ -177,7 +177,7 @@ docType: "<$ doc.docType $>"
 <h2>Installation</h2>
 <ol class="installation">
   <li>Install the Cordova and Ionic Native plugins:<br>
-    <pre><code class="nohighlight">$ <@ if prop.install @><$ prop.install $><@ else @>ionic cordova plugin add --save <$ prop.plugin $><@ endif @>
+    <pre><code class="nohighlight">$ <@ if prop.install @><$ prop.install $><@ else @>ionic cordova plugin add <$ prop.plugin $><@ endif @>
 $ npm install --save @ionic-native/<$ doc.npmId $>
 </code></pre>
   </li>

--- a/scripts/docs/templates/common.template.html
+++ b/scripts/docs/templates/common.template.html
@@ -175,9 +175,14 @@ docType: "<$ doc.docType $>"
 
 <# --- Install commands --- #>
 <h2>Installation</h2>
-<pre><code class="nohighlight">$ <@ if prop.install @><$ prop.install $><@ else @>ionic plugin add --save <$ prop.plugin $><@ endif @>
+<ol>
+  <li style="font-size:15px; margin-bottom:10px;">Install the Cordova and Ionic Native plugins:<br>
+    <pre style="margin-top:10px;"><code class="nohighlight">$ <@ if prop.install @><$ prop.install $><@ else @>ionic plugin add --save <$ prop.plugin $><@ endif @>
 $ npm install --save @ionic-native/<$ doc.npmId $>
 </code></pre>
+  </li>
+  <li><a href="https://ionicframework.com/docs/native/#Add_Plugins_to_Your_App_Module">Add this plugin to your app's module</a></li>
+</ol>
 
 <# --- Plugin supported platforms --- #>
 <@ if prop.platforms @>


### PR DESCRIPTION
This PR makes it clear that installation is a two step process of 1) running commands on the CLI and 2) "Add this plugin to your app's module" (which links to the explanation in the Ionic Native Overiew at https://ionicframework.com/docs/native/#Add_Plugins_to_Your_App_Module). It also switches the plugin description with the installation commands.

This way users that "miss" this part of the docs will have a better Ionic Native experience and I hope most of the "This Ionic Native plugin is not working and throwing this strange error" posts in the forum will go away.

Currently:

![bildschirmfoto am 2017-05-05 um 13 36 37](https://cloud.githubusercontent.com/assets/183673/25744313/83cf842e-3199-11e7-8422-a146bfa12cc4.png)

After this PR is accepted and docs regenerated:

![bildschirmfoto am 2017-05-05 um 13 36 45](https://cloud.githubusercontent.com/assets/183673/25744316/88d99234-3199-11e7-92dc-e3aca1198499.png)