### PR TITLE
docs(iab): https://ionicframework.com/

### DIFF
--- a/src/@ionic-native/plugins/in-app-browser/index.ts
+++ b/src/@ionic-native/plugins/in-app-browser/index.ts
@@ -145,7 +145,7 @@ export class InAppBrowserObject {
  * ...
  *
  *
- * const browser = this.iab.create('https://ionic.io');
+ * const browser = this.iab.create('https://ionicframework.com/');
  *
  * browser.executeScript(...);
  * browser.insertCSS(...);


### PR DESCRIPTION
Nothing special I just changed https://ionic.io because the URL redirects to http://ionicframework.com/

One improvement would be if https://ionic.io would redirect to https:// and not to http://