### PR TITLE
docs(email composer): out of beta

### DIFF
--- a/src/@ionic-native/plugins/email-composer/index.ts
+++ b/src/@ionic-native/plugins/email-composer/index.ts
@@ -25,14 +25,11 @@ export interface EmailComposerOptions {
 
 
 /**
- * @beta
  * @name Email Composer
  * @description
  *
  * Requires Cordova plugin: cordova-plugin-email-composer. For more info, please see the [Email Composer plugin docs](https://github.com/hypery2k/cordova-email-plugin).
  *
- * DISCLAIMER: This plugin is experiencing issues with the latest versions of Cordova. Use at your own risk. Functionality is not guaranteed. Please stay tuned for a more stable version.
- * A good alternative to this plugin is the social sharing plugin.
  *
  * @usage
  * ```typescript


### PR DESCRIPTION
This repo is out of beta and they fixed problems with newer android versions

https://github.com/hypery2k/cordova-email-plugin/commit/171b99b