### PR TITLE
add args to panBy()

### DIFF
--- a/src/@ionic-native/plugins/google-maps/index.ts
+++ b/src/@ionic-native/plugins/google-maps/index.ts
@@ -363,7 +363,7 @@ export class GoogleMap {
   remove(): void { }
 
   @CordovaInstance({ sync: true })
-  panBy(): void { }
+  panBy(x: string, y: string): void { }
 }
 
 /**


### PR DESCRIPTION
In the google-maps plugin, there is a `panBy()` function with no arguments. Looking at [the plugin code](https://github.com/mapsplugin/cordova-plugin-googlemaps/blob/master/www/googlemaps-cdv-plugin.js), it should take two numeric strings.