### PR TITLE
Removed unecessary parameter for map method fromPointToLatLng.

### DIFF
--- a/src/@ionic-native/plugins/google-maps/index.ts
+++ b/src/@ionic-native/plugins/google-maps/index.ts
@@ -351,7 +351,7 @@ export class GoogleMap {
    * @returns {Promise<LatLng>}
    */
   @CordovaInstance()
-  fromPointToLatLng(point: any, latLng: LatLng): Promise<LatLng> { return; }
+  fromPointToLatLng(point: any): Promise<LatLng> { return; }
 
   /**
    * @returns {Promise<any>}


### PR DESCRIPTION
Fixed number of parameters to match the cordova-googlemaps [plugin](https://github.com/mapsplugin/cordova-plugin-googlemaps-doc/blob/master/v1.4.0/class/Map/README.md).