### PR TITLE
fix(diagnostic plugin): fix Cordova decorator in camera API

### DIFF
--- a/src/@ionic-native/plugins/diagnostic/index.ts
+++ b/src/@ionic-native/plugins/diagnostic/index.ts
@@ -148,7 +148,7 @@ export class Diagnostic extends IonicNativePlugin {
    *  cordova-plugin-camera@2.2+ requires both of these permissions. Defaults to true.   
    * @returns {Promise<any>}
    */
-  @Cordova({ successIndex: 1, errorIndex: 2 })
+  @Cordova({ callbackOrder: 'reverse' })
   isCameraAvailable( externalStorage?: boolean ): Promise<any> { return; }
 
   /**
@@ -257,7 +257,7 @@ export class Diagnostic extends IonicNativePlugin {
    *  cordova-plugin-camera@2.2+ requires both of these permissions. Defaults to true.
    * @returns {Promise<any>}
    */
-  @Cordova({ platforms: ['Android', 'iOS'], successIndex: 1, errorIndex: 2 })
+  @Cordova({ platforms: ['Android', 'iOS'], callbackOrder: 'reverse' })
   isCameraAuthorized( externalStorage?: boolean ): Promise<any> { return; }
 
   /**
@@ -266,7 +266,7 @@ export class Diagnostic extends IonicNativePlugin {
    *  cordova-plugin-camera@2.2+ requires both of these permissions. Defaults to true.
    * @returns {Promise<any>}
    */
-  @Cordova({ platforms: ['Android', 'iOS'], successIndex: 1, errorIndex: 2 })
+  @Cordova({ platforms: ['Android', 'iOS'], callbackOrder: 'reverse' })
   getCameraAuthorizationStatus( externalStorage?: boolean ): Promise<any> { return; }
 
   /**
@@ -275,7 +275,7 @@ export class Diagnostic extends IonicNativePlugin {
    *  cordova-plugin-camera@2.2+ requires both of these permissions. Defaults to true.
    * @returns {Promise<any>}
    */
-  @Cordova({ platforms: ['Android', 'iOS'], successIndex: 1, errorIndex: 2 })
+  @Cordova({ platforms: ['Android', 'iOS'], callbackOrder: 'reverse' })
   requestCameraAuthorization( externalStorage?: boolean ): Promise<any> { return; }
 
   /**


### PR DESCRIPTION
by reversing callback order, rather than specifying callback indices (as added in commit 58db96147e973a264e1c013f46f93bccdfd9dfb4 due to recommendation in #1458), since the latter causes callbacks not to be invoked when using the plugin at runtime. This is consistent with the original implementation, e.g. for requestLocationAuthorization() which also has an optional 3rd argument.