### PR TITLE
Use correct admobpro options for prepareInterstitial

### DIFF
--- a/src/@ionic-native/plugins/admob/index.ts
+++ b/src/@ionic-native/plugins/admob/index.ts
@@ -112,7 +112,7 @@ export interface AdExtras {
  *   } else if (this.platform.is('ios')) {
  *     adId = 'YOUR_ADID_IOS';
  *   }
- *   this.admob.prepareInterstitial(adId)
+ *   this.admob.prepareInterstitial({adId: adId})
  *     .then(() => { this.admob.showInterstitial(); });
  * }
  *


### PR DESCRIPTION
Using the example in the previous version of this document, calling `prepareInterstitial(adId)` resulted in an `-[__NSCFString count]: unrecognized selector sent to instance` exception on the ios platform. This was alleviated by changing the call to `prepareInterstitial({adId: adId})` 
(e.g. passing in an options object vs. just the adid string).

Interestingly enough this did not happen when calling `createBanner()`, so perhaps this is a bug with the admobpro plugin. In any case, this documentation adjustment should help folks in the meantime. 