### PR TITLE
fix (in-app-purchase-3) typing and docs

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/in-app-purchase-2/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/in-app-purchase-2/index.ts
@@ -248,6 +248,9 @@ export class IAPError {
  *  - **macOS** version 10
  *  - **Xbox One**
  *    - (and any platform supporting Microsoft's UWP)
+ *  - **cordova-plugin-purchase** version 12 or lower.
+ * @see https://github.com/j3k0/cordova-plugin-purchase/wiki/HOWTO:-Migrate-to-v13 For cordova-plugin-purchase versions
+ * 13 and higher, use awesome cordova plugin InAppPurchase3 instead
  * @usage
  * ```typescript
  * import { InAppPurchase2 } from '@awesome-cordova-plugins/in-app-purchase-2/ngx';


### PR DESCRIPTION
include changes from #4854 and ran `npm run readmes` locally to check if it's working :heavy_check_mark: 
related to #4848 
related to #4868 (will fix future versions deployment)

fixes : 
- fixes `npm run readme`
- fixes initialize() wrong return type
- updated doc for cordova-plugin-purchase version 13 usage
- add a deprecation warding on the in-app-purchase-2 documentation

since my first PR, I've run tests and can confirm this plugin works with tests purchases. (both from local tests and Google Play Store / iOS App Store test payments)
Since I don't have live product, I didn't tested it with live purchase