### PR TITLE
docs(core): fix dead link to Capacitor docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ These plugins are submitted and maintained by the community. While community mem
 
 ## Capacitor Support
 
-In addition to Cordova, Awesome Cordova Plugins also works with [Capacitor](https://capacitorjs.com/), Ionic's official native runtime. Basic usage below. For complete details, [see the Capacitor documentation](https://capacitorjs.com/docs/cordova/using-cordova-plugins).
+In addition to Cordova, Awesome Cordova Plugins also works with [Capacitor](https://capacitorjs.com/), Ionic's official native runtime. Basic usage below. For complete details, [see the Capacitor documentation](https://capacitorjs.com/docs/plugins/cordova).
 
 ## Usage
 


### PR DESCRIPTION
## Description

The existing link is dead ([archive](https://web.archive.org/web/20210512053759/https://capacitorjs.com/docs/cordova/using-cordova-plugins)). Looking at the current docs, the proposed change's URL appears to be the spiritual succesor.

## Type of change

- [ ] Bug fix
- [ ] New plugin wrapper
- [ ] Enhancement to existing plugin
- [x] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe)

## Checklist

- [x] I have read the [Developer Guide](../DEVELOPER.md)
- [x] My code follows the existing code style (`npm run lint`)
- [ ] I have tested my changes locally (`npm run build && npm test`)
- [x] I have added/updated documentation if necessary
- [x] Commit messages follow the `type(scope): subject` format
