### PR TITLE
fix(media-capture): correct CaptureError.code type to number

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/media-capture/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/media-capture/index.ts
@@ -61,7 +61,16 @@ export interface MediaFileData {
 }
 
 export interface CaptureError {
-  code: string;
+  /**
+   * One of the `CaptureError` codes:
+   * - `0` - CAPTURE_INTERNAL_ERR: Camera or microphone failed to capture image or sound.
+   * - `1` - CAPTURE_APPLICATION_BUSY: Camera application or audio capture application is currently serving other capture request.
+   * - `2` - CAPTURE_INVALID_ARGUMENT: Invalid use of the API (e.g. limit parameter has value less than one).
+   * - `3` - CAPTURE_NO_MEDIA_FILES: User exited camera application or audio capture application before capturing anything.
+   * - `4` - CAPTURE_PERMISSION_DENIED: User denied permissions required to perform the capture request.
+   * - `20` - CAPTURE_NOT_SUPPORTED: The requested capture operation is not supported.
+   */
+  code: number;
 }
 
 export interface CaptureAudioOptions {


### PR DESCRIPTION
Compared against upstream `cordova-plugin-media-capture@6.0.0` (2025-02-26).

**Added APIs:** none — every documented method, property, and interface (`captureAudio`, `captureImage`, `captureVideo`, `supportedAudioModes`, `supportedImageModes`, `supportedVideoModes`, `onPendingCaptureResult`, `onPendingCaptureError`, `MediaFile`, `MediaFileData`, `CaptureError`, `CaptureAudioOptions`, `CaptureImageOptions`, `CaptureVideoOptions`, `ConfigurationData`) is already present in the wrapper and matches upstream. Platforms (`Android`, `Browser`, `iOS`, `Windows`) in `@Plugin` metadata match `plugin.xml`.

**Newly deprecated APIs:** none.

**Fixed signature:** `CaptureError.code` was typed as `string` but upstream's `www/CaptureError.js` defines it as a `number` with constants `CAPTURE_INTERNAL_ERR = 0`, `CAPTURE_APPLICATION_BUSY = 1`, `CAPTURE_INVALID_ARGUMENT = 2`, `CAPTURE_NO_MEDIA_FILES = 3`, `CAPTURE_PERMISSION_DENIED = 4`, `CAPTURE_NOT_SUPPORTED = 20`. Updated the type and documented the constants in JSDoc.

**Sources:**
- https://github.com/apache/cordova-plugin-media-capture/blob/master/README.md
- https://github.com/apache/cordova-plugin-media-capture/blob/master/www/CaptureError.js
- https://github.com/apache/cordova-plugin-media-capture/blob/master/www/capture.js
- https://github.com/apache/cordova-plugin-media-capture/blob/master/plugin.xml