### PR TITLE
feat(network): add 5G connection type support

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/network/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/network/index.ts
@@ -18,6 +18,7 @@ export enum Connection {
   CELL_2G = '2g',
   CELL_3G = '3g',
   CELL_4G = '4g',
+  CELL_5G = '5g',
   CELL = 'cellular',
   NONE = 'none',
 }
@@ -62,7 +63,7 @@ export enum Connection {
  *
  * ```
  * @advanced
- * The `type` property will return one of the following connection types: `unknown`, `ethernet`, `wifi`, `2g`, `3g`, `4g`, `cellular`, `none`
+ * The `type` property will return one of the following connection types: `unknown`, `ethernet`, `wifi`, `2g`, `3g`, `4g`, `5g`, `cellular`, `none`
  */
 @Plugin({
   pluginName: 'Network',
@@ -83,6 +84,7 @@ export class Network extends AwesomeCordovaNativePlugin {
     CELL_2G: '2g',
     CELL_3G: '3g',
     CELL_4G: '4g',
+    CELL_5G: '5g',
     CELL: 'cellular',
     NONE: 'none',
   };
@@ -98,6 +100,7 @@ export class Network extends AwesomeCordovaNativePlugin {
    * Downlink Max Speed
    *
    * @returns {string}
+   * @deprecated Not part of the upstream cordova-plugin-network-information API (verified against v3.1.0 types/index.d.ts and README). Retained for backwards compatibility only.
    */
   @CordovaProperty() downlinkMax: string;
 
@@ -109,7 +112,7 @@ export class Network extends AwesomeCordovaNativePlugin {
   @CordovaCheck()
   onChange(): Observable<'connected' | 'disconnected'> {
     return merge(
-      this.onConnect().pipe(mapTo('connected')),
+      this.onConnect().pipe(mapTo('connected')) as Observable<'connected'>,
       this.onDisconnect().pipe(mapTo('disconnected')) as Observable<'disconnected'>
     );
   }


### PR DESCRIPTION
## Summary

Compared against upstream `cordova-plugin-network-information` v3.1.0 (repo: https://github.com/apache/cordova-plugin-network-information, docs: https://github.com/apache/cordova-plugin-network-information/blob/master/README.md, types: https://github.com/apache/cordova-plugin-network-information/blob/master/types/index.d.ts).

**Added APIs:**
- `Connection.CELL_5G` enum member (`'5g'`)
- `Network.Connection.CELL_5G` constant (`'5g'`) on the plugin class

**Newly deprecated APIs:**
- `Network.downlinkMax` — not present in the current upstream `Connection` interface (`types/index.d.ts`) or README as of v3.1.0. Kept for backwards compatibility, marked `@deprecated`.

**Other:**
- Fixed a pre-existing `Observable<'connected' | 'disconnected'>` type error in `onChange()` (missing explicit cast on the `mapTo('connected')` branch, mirroring the existing cast on `mapTo('disconnected')`), required for `tsc --noEmit` to pass clean.

## Test plan
- [x] `npx eslint src/@awesome-cordova-plugins/plugins/network/index.ts` — 0 errors (pre-existing `no-explicit-any` warnings only)
- [x] `npx tsc -p tsconfig.json --noEmit 2>&1 | grep "plugins/network/"` — no output
