### PR TITLE
feat(sqlite): add Android provider options, fix abort call, add Browser platform

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/sqlite/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/sqlite/index.ts
@@ -35,6 +35,17 @@ export interface SQLiteDatabaseConfig {
    * support encrypted databases with https://github.com/litehelpers/Cordova-sqlcipher-adapter
    */
   key?: string;
+  /**
+   * Use the Android system database provider instead of the default lightweight NDK connector.
+   * Set to 'system' to avoid multiple-SQLite-connection corruption issues on Android. Example: 'system'
+   */
+  androidDatabaseProvider?: string;
+  /**
+   * Android-only workaround that closes and reopens the database file at the end of every committed
+   * transaction, to work around a database locking issue when `androidDatabaseProvider: 'system'` is used.
+   * Set to 1 to enable. Only applied to `sqlBatch`/`transaction`, not to `executeSql`.
+   */
+  androidLockWorkaround?: number;
 }
 
 /**
@@ -135,8 +146,13 @@ export class SQLiteObject {
     return;
   }
 
+  /**
+   * The underlying plugin method is named `abortAllPendingTransactions`; mapped explicitly here since this
+   * method's name differs in casing.
+   */
   @CordovaInstance({
     sync: true,
+    methodName: 'abortAllPendingTransactions',
   })
   abortallPendingTransactions(): void {}
 }
@@ -181,7 +197,7 @@ export class SQLiteObject {
   pluginRef: 'sqlitePlugin',
   plugin: 'cordova-sqlite-storage',
   repo: 'https://github.com/litehelpers/Cordova-sqlite-storage',
-  platforms: ['Android', 'iOS', 'macOS', 'Windows'],
+  platforms: ['Android', 'Browser', 'iOS', 'macOS', 'Windows'],
 })
 @Injectable()
 export class SQLite extends AwesomeCordovaNativePlugin {


### PR DESCRIPTION
## Summary

Compared the wrapper against upstream `cordova-sqlite-storage` 7.0.0 (npm dist-tag latest, published 2025-01-28). A byte-for-byte diff of `www/SQLitePlugin.js` across 5.1.0 → 6.0.0 → 7.0.0 confirmed the JS-facing API has been unchanged since at least 5.1.0 (the v7 major bump is a native/build-dependency change, not a JS API change), so no exported symbol needed removal or deprecation.

**Documentation source used:** https://github.com/litehelpers/Cordova-sqlite-storage (redirects to https://github.com/brody2consult/cordova-sqlite-storage) `README.md`, cross-checked against `www/SQLitePlugin.js` for versions 5.1.0, 6.0.0, and 7.0.0.

### Added APIs
- `SQLiteDatabaseConfig.androidDatabaseProvider?: string` — documented `openDatabase()` option (`'system'`) to use the Android system DB provider instead of the default NDK connector, avoiding multi-connection corruption.
- `SQLiteDatabaseConfig.androidLockWorkaround?: number` — documented `openDatabase()` option (`1`) working around an Android DB-locking issue when `androidDatabaseProvider: 'system'` is used.
- `'Browser'` added to the `@Plugin` `platforms` metadata — the plugin has documented browser support (via `sql.js`) since at least 5.1.0 but it was missing from the wrapper's platform list.

### Fixed
- `SQLiteObject.abortallPendingTransactions()` was calling a nonexistent Cordova method (case mismatch: the actual plugin method is `abortAllPendingTransactions`). Added `methodName: 'abortAllPendingTransactions'` to the `@CordovaInstance` decorator so the call now reaches the real method. The wrapper's exported method name is unchanged for backwards compatibility.

### Newly deprecated APIs
None — no exported method, interface, property, or enum was removed upstream between the wrapper's last update and 7.0.0.

## Test plan
- [x] `npx eslint src/@awesome-cordova-plugins/plugins/sqlite/index.ts` — 0 errors (pre-existing `no-explicit-any`/jsdoc warnings only)
- [x] `npx tsc -p tsconfig.json --noEmit 2>&1 | grep "plugins/sqlite/"` — no output
