### PR TITLE
feat(intercom): add suppressProactiveContent method

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/intercom/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/intercom/index.ts
@@ -220,6 +220,17 @@ export class Intercom extends AwesomeCordovaNativePlugin {
   }
 
   /**
+   * Suppress the given proactive content types, independently of `setInAppMessageVisibility`.
+   * @note All proactive content is visible by default; pass an empty array to unsuppress all.
+   *
+   * @param types An array of content type strings to suppress, e.g. `[IntercomPresentContentType.Carousel, IntercomPresentContentType.Survey]`.
+   */
+  @Cordova()
+  suppressProactiveContent(types: IntercomPresentContentType[]): Promise<void> {
+    return;
+  }
+
+  /**
    * Hide all Intercom windows that are currently displayed.
    * This will hide the Messenger, Help Center, Articles, and in-product messages (eg. Mobile Carousels, chats, and posts).
    */
@@ -375,8 +386,7 @@ export enum IntercomPresentContentType {
 }
 
 export type IntercomPresentContent =
-  | { id: string; type: IntercomPresentContentType }
-  | { ids: string[]; type: IntercomPresentContentType };
+  { id: string; type: IntercomPresentContentType } | { ids: string[]; type: IntercomPresentContentType };
 
 export interface IntercomUserAttributes {
   email?: string;


### PR DESCRIPTION
## Summary
- Compared the wrapper against `cordova-plugin-intercom@16.4.0` (released 2026-07-20), source: https://unpkg.com/cordova-plugin-intercom@16.4.0/www/intercom.js
- Upstream added `suppressProactiveContent(types)` in 16.4.0, letting apps suppress carousel/survey proactive content independently of `setInAppMessageVisibility`. Added it to the wrapper, typed as `IntercomPresentContentType[]` reusing the existing enum.
- No other API changes since the wrapper was last updated (2025-03-10): all other methods, signatures, interfaces, and enums are unchanged upstream.

**Added APIs**
- `suppressProactiveContent(types: IntercomPresentContentType[]): Promise<void>`

**Newly deprecated APIs**
- None

**Potentially breaking**
- None — no existing type was changed.

## Test plan
- [x] `npx eslint src/@awesome-cordova-plugins/plugins/intercom/index.ts` — no errors (pre-existing `no-explicit-any` warnings only)
- [x] `npx tsc -p tsconfig.json --noEmit 2>&1 | grep "plugins/intercom/"` — no output
