### PR TITLE
feat(camera-preview): add white balance controls, getSupportedColorEffects and getBlob

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/camera-preview/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/camera-preview/index.ts
@@ -30,9 +30,9 @@ export interface CameraPreviewOptions {
 
   /** Preview box drag across the screen, default 'false' */
   previewDrag?: boolean;
-  
-  /** Capture images to a file and return back the file path instead of returning base64 encoded data. */
-  storeToFile: boolean;
+
+  /** Capture images to a file and return back the file path instead of returning base64 encoded data. Defaults to false */
+  storeToFile?: boolean;
 
   /** Preview box to the back of the webview (true => back, false => front) , default false */
   toBack?: boolean;
@@ -166,6 +166,19 @@ export class CameraPreview extends AwesomeCordovaNativePlugin {
     CUSTOM: 'custom',
   };
 
+  WHITE_BALANCE_MODE = {
+    LOCK: 'lock',
+    AUTO: 'auto',
+    CONTINUOUS: 'continuous',
+    INCANDESCENT: 'incandescent',
+    CLOUDY_DAYLIGHT: 'cloudy-daylight',
+    DAYLIGHT: 'daylight',
+    FLUORESCENT: 'fluorescent',
+    SHADE: 'shade',
+    TWILIGHT: 'twilight',
+    WARM_FLUORESCENT: 'warm-fluorescent',
+  };
+
   FLASH_MODE = {
     OFF: 'off',
     ON: 'on',
@@ -294,6 +307,16 @@ export class CameraPreview extends AwesomeCordovaNativePlugin {
     errorIndex: 2,
   })
   takeSnapshot(options?: CameraPreviewPictureOptions): Promise<any> {
+    return;
+  }
+
+  /**
+   * Get color effects supported by the camera device currently started. Android only.
+   *
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  getSupportedColorEffects(): Promise<any> {
     return;
   }
 
@@ -508,6 +531,40 @@ export class CameraPreview extends AwesomeCordovaNativePlugin {
   }
 
   /**
+   * Get white balance modes supported by the camera device currently started.
+   *
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  getSupportedWhiteBalanceModes(): Promise<any> {
+    return;
+  }
+
+  /**
+   * Get the current white balance mode of the camera device currently started.
+   *
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  getWhiteBalanceMode(): Promise<any> {
+    return;
+  }
+
+  /**
+   * Set the white balance mode for the camera device currently started.
+   *
+   * @param {string} [whiteBalanceMode] 'lock', 'auto', 'continuous', 'incandescent', 'cloudy-daylight', 'daylight', 'fluorescent', 'shade', 'twilight' or 'warm-fluorescent'
+   * @returns {Promise<any>}
+   */
+  @Cordova({
+    successIndex: 1,
+    errorIndex: 2,
+  })
+  setWhiteBalanceMode(whiteBalanceMode?: string): Promise<any> {
+    return;
+  }
+
+  /**
    * Set specific focus point. Note, this assumes the camera is full-screen.
    *
    * @param {number} xPoint
@@ -546,6 +603,20 @@ export class CameraPreview extends AwesomeCordovaNativePlugin {
    */
   @Cordova()
   getCameraCharacteristics(): Promise<any> {
+    return;
+  }
+
+  /**
+   * Convert a local file (e.g. a `file://` path returned by takePicture with storeToFile) into a Blob.
+   *
+   * @param {string} path the local url to convert
+   * @returns {Promise<any>}
+   */
+  @Cordova({
+    successIndex: 1,
+    errorIndex: 2,
+  })
+  getBlob(path: string): Promise<any> {
     return;
   }
 }


### PR DESCRIPTION
Sync the `camera-preview` wrapper with upstream `cordova-plugin-camera-preview@0.14.0` (last touched 2022-01-06, upstream now at 0.14.0 / 2025-07-12).

**Source compared against:**
- https://raw.githubusercontent.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/v0.14.0/www/CameraPreview.js (ground truth for exec calls)
- https://raw.githubusercontent.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/v0.14.0/typescript/CameraPreview.d.ts
- https://raw.githubusercontent.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview/v0.14.0/README.md

**Added APIs:**
- `getSupportedColorEffects()`
- `getSupportedWhiteBalanceModes()`
- `getWhiteBalanceMode()`
- `setWhiteBalanceMode(whiteBalanceMode?: string)`
- `getBlob(path: string)`
- `WHITE_BALANCE_MODE` constant object (matches upstream `CameraPreview.WHITE_BALANCE_MODE`)

Note: the upstream `.d.ts` names one of these `getSupportedWhiteBalanceMode`, but the actual `www/CameraPreview.js` implementation (the exec ground truth) exposes it as `getWhiteBalanceMode`, which is what this wrapper uses -- the typings file has a naming bug.

**Newly deprecated APIs:** none -- nothing was removed upstream.

**Potentially breaking:**
- `CameraPreviewOptions.storeToFile` changed from required (`storeToFile: boolean`) to optional (`storeToFile?: boolean`). Upstream's own typings (`CameraPreviewStartCameraOptions.storeToFile?: boolean`) and JS implementation (`options.storeToFile = options.storeToFile || false;`) both treat it as optional with a default of `false`. This loosens the type (no existing caller that already set the field is affected) but is called out here per the type-change policy.

**Verification:**
- `npx eslint src/@awesome-cordova-plugins/plugins/camera-preview/index.ts` -> 0 errors (pre-existing `no-explicit-any` warnings only)
- `npx tsc -p tsconfig.json --noEmit | grep "plugins/camera-preview/"` -> no output
