### PR TITLE
feat(sms): add requestPermission method and android slot option

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/sms/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/sms/index.ts
@@ -18,6 +18,12 @@ export interface SmsOptionsAndroid {
    * Set to "INTENT" to send SMS with the native android SMS messaging. Leaving it empty will send the SMS without opening any app.
    */
   intent?: string;
+
+  /**
+   * Selects which SIM to use on dual-SIM devices when sending with no intent. Use "0" for the primary SIM slot and "1" for the secondary SIM slot.
+   * If no slot is specified the default SIM slot will be used.
+   */
+  slot?: string;
 }
 
 /**
@@ -76,6 +82,18 @@ export class SMS extends AwesomeCordovaNativePlugin {
     platforms: ['Android'],
   })
   hasPermission(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Requests permission to send SMS (Android Marshmallow and later)
+   *
+   * @returns {Promise<boolean>} returns a promise that resolves with a boolean that indicates if permission was granted
+   */
+  @Cordova({
+    platforms: ['Android'],
+  })
+  requestPermission(): Promise<boolean> {
     return;
   }
 }


### PR DESCRIPTION
## Summary
Updated the SMS wrapper against `cordova-sms-plugin@1.0.5` (latest), compared against the upstream README (`readme.md`) and JS source (`www/sms.js`) at https://github.com/cordova-sms/cordova-sms-plugin/tree/master.

- Added `requestPermission(): Promise<boolean>` — wraps `sms.requestPermission(success, failure)` (Android only, Marshmallow+). Verified against `src/android/Sms.java`: native side resolves with `true` on grant, rejects with an error string on denial, matching the `hasPermission` pattern already in the wrapper.
- Added `slot?: string` to `SmsOptionsAndroid` — wraps the `options.android.slot` field added upstream for dual-SIM devices ("0" = primary, "1" = secondary), read directly in `www/sms.js`'s `sms.send`.

**Newly deprecated APIs:** none — no upstream APIs were removed.

**Potentially breaking:** none — no existing exported member's type was changed.

Source used: https://raw.githubusercontent.com/cordova-sms/cordova-sms-plugin/master/readme.md and https://raw.githubusercontent.com/cordova-sms/cordova-sms-plugin/master/www/sms.js (plus `src/android/Sms.java` to confirm `requestPermission`'s resolved value type).

## Test plan
- [x] `npx eslint src/@awesome-cordova-plugins/plugins/sms/index.ts` — only a pre-existing warning on the untouched `send` method
- [x] `npx tsc -p tsconfig.json --noEmit 2>&1 | grep "plugins/sms/"` — no output
