### PR TITLE
feat(background-upload): add uploadDuration and finishUploadTime to UploadEvent

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/background-upload/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/background-upload/index.ts
@@ -21,6 +21,8 @@ export interface UploadEvent {
   errorCode?: number; // error code for any exception encountered
   progress?: any; // progress for ongoing upload
   eventId?: string; // id of the event
+  uploadDuration?: number; // duration of the upload in milliseconds (UPLOADED state only)
+  finishUploadTime?: number; // timestamp (ms) at which the upload finished (UPLOADED state only)
 }
 
 export interface FTMPayloadOptions {


### PR DESCRIPTION
## Summary

Compared the wrapper against upstream `@spoonconsulting/cordova-plugin-background-upload@4.1.3` (latest, released 2026-01-23). The plugin ships no TypeScript typings, so the API was verified against the actual JS bridge (`www/FileTransferManager.js`) and native source (Android `FileTransferBackground.java`/`UploadTask.java`, iOS `FileUploader.m`) at that version.

All existing methods (`startUpload`, `removeUpload`, `acknowledgeEvent`, `destroy`, `init`) and their signatures are unchanged and still match upstream. No APIs were removed upstream, so nothing needed a `@deprecated` marker.

**Added APIs**

The 4.1.2 changelog entry "Return upload start and end time in upload response" adds two fields to the `UPLOADED` event payload on both platforms (confirmed in native source: `FileTransferBackground.java` `sendSuccess()` puts `uploadDuration`/`finishUploadTime`; iOS `FileUploader.m` sets `event[@"uploadDuration"]`/`event[@"finishUploadTime"]`). Added as optional properties on the existing `UploadEvent` interface:
- `uploadDuration?: number` — duration of the upload in milliseconds (UPLOADED state only)
- `finishUploadTime?: number` — timestamp (ms) the upload finished (UPLOADED state only)

**Newly deprecated APIs**

None — no upstream removals found.

**Potentially breaking**

None — purely additive optional properties.

**Source**

- https://unpkg.com/@spoonconsulting/cordova-plugin-background-upload@4.1.3/www/FileTransferManager.js
- https://unpkg.com/@spoonconsulting/cordova-plugin-background-upload@4.1.3/README.md
- https://raw.githubusercontent.com/spoonconsulting/cordova-plugin-background-upload/master/src/android/FileTransferBackground.java
- https://raw.githubusercontent.com/spoonconsulting/cordova-plugin-background-upload/master/src/ios/FileUploader.m
- https://raw.githubusercontent.com/spoonconsulting/cordova-plugin-background-upload/master/CHANGELOG.md

## Test plan
- [x] `npx eslint src/@awesome-cordova-plugins/plugins/background-upload/index.ts` — 0 errors (pre-existing `no-explicit-any` warnings only)
- [x] `npx tsc -p tsconfig.json --noEmit` — no errors for `plugins/background-upload/`