### PR TITLE
feat(anyline): add setDefaultScanStartPlatformOptions and note legacy API deprecation

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/anyline/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/anyline/index.ts
@@ -9,6 +9,10 @@ export interface AnylineConfig {
  * @name Anyline
  * @description
  * Anyline provides an easy-to-use SDK for applications to enable Optical Character Recognition (OCR) on mobile devices.
+ *
+ * @deprecated since v56.0.0. This legacy `AnylineSDK` API remains functional but upstream recommends migrating to the
+ * new `AnylineInfinityPlugin` API (exposed natively as `window.AnylineInfinity`), which is not covered by this wrapper.
+ * See https://documentation.anyline.com/cordova-plugin-component/latest/infinity-plugins/upgrade-guide.html
  * @usage
  * ```typescript
  * import { Anyline } from '@awesome-cordova-plugins/anyline/ngx';
@@ -57,6 +61,19 @@ export class Anyline extends AwesomeCordovaNativePlugin {
    */
   @Cordova()
   scan(config: AnylineConfig): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets platform-specific scanning options, such as selecting the camera API on Android
+   * (CameraX vs Camera1) or managing camera permission handling. Must be called before `scan`.
+   *
+   * @param scanStartPlatformOptionsString {string} A JSON-stringified object of platform-specific attributes,
+   * e.g. `JSON.stringify({ androidScanViewAttributes: { useCameraX: false } })`
+   * @returns {Promise<any>} Returns a promise that resolves when the options have been set
+   */
+  @Cordova()
+  setDefaultScanStartPlatformOptions(scanStartPlatformOptionsString: string): Promise<any> {
     return;
   }
 }


### PR DESCRIPTION
## Summary

Updated the `anyline` wrapper against `io-anyline-cordova@56.2.0` (compared against `55.9.0`-`56.2.0` release notes and `www/anyline.js` / `plugin.xml` from the published package).

Source used: https://unpkg.com/io-anyline-cordova@56.2.0/www/anyline.js, https://unpkg.com/io-anyline-cordova@56.2.0/plugin.xml, and https://documentation.anyline.com/cordova-plugin-component/latest/release-notes.html

The wrapper's `pluginRef: 'Anyline'` maps to `window.Anyline` (native `AnylineSDK`), which is `<clobbers target="window.Anyline">` in `plugin.xml`. That surface's 4 existing methods (`checkLicense`, `initAnylineSDK`, `getSDKVersion`, `scan`) are unchanged upstream.

Upstream also shipped an entirely separate, much larger `AnylineInfinityPlugin` surface (`window.AnylineInfinity`, added in `56.0.0`) with its own schema-driven session API and ~100KB of accompanying TypeScript typings (`sdk_config.ts`, `wrapper_session_parameters.ts`). That is a distinct plugin surface (different `pluginRef`/native class), not an evolution of the wrapped `Anyline` class, so it is out of scope for this conservative, additive update — a speculative rewrite of that surface was intentionally avoided per the size/ambiguity of the jump.

### Added APIs
- `setDefaultScanStartPlatformOptions(scanStartPlatformOptionsString: string): Promise<any>` — added upstream in `55.9.0`. Sets platform-specific scan options (e.g. Android CameraX vs Camera1, camera permission handling); must be called before `scan`. Takes a JSON-stringified options object, matching the exact contract of `Anyline.prototype.setDefaultScanStartPlatformOptions` in `www/anyline.js`.

### Newly deprecated APIs
- None removed. Upstream `56.0.0` release notes mark the entire legacy `AnylineSDK` plugin (i.e. the `window.Anyline` object this wrapper targets) as deprecated in favor of `AnylineInfinityPlugin`, while stating it "remains functional." Documented this via a class-level `@deprecated` JSDoc note (all 5 existing + 1 new method signatures are unchanged and still work).

### Potentially breaking
None. No existing method/interface/property signature was changed.

## Test plan
- [x] `npx eslint src/@awesome-cordova-plugins/plugins/anyline/index.ts` — 0 errors (pre-existing `no-explicit-any` warnings only)
- [x] `npx tsc -p tsconfig.json --noEmit 2>&1 | grep "plugins/anyline/"` — empty output
