### PR TITLE
fix(cashfree-pg): mark doDropPayment as deprecated per upstream 1.1.0

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/cashfree-pg/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/cashfree-pg/index.ts
@@ -304,6 +304,7 @@ export class CFPaymentGateway extends AwesomeCordovaNativePlugin {
   /**
    * Initiate Drop Payment.
    * @param {CFDropCheckoutPayment} [dropObject] dropPaymentObject information
+   * @deprecated Use doWebCheckoutPayment instead. Deprecated upstream as of cordova-plugin-cashfree-pg 1.1.0.
    */
   @Cordova()
   doDropPayment(dropObject: CFDropCheckoutPayment) {


### PR DESCRIPTION
## Summary
Compared the wrapper against upstream `cordova-plugin-cashfree-pg@1.1.0` (npm tarball: `dist/CFPaymentGateway.d.ts`, `dist/CFPaymentGateway.js`, `README.md`) versus the previously-compared `1.0.12`.

- **Upstream API surface**: `CFPaymentGatewayService` exposes exactly `doUPIPayment`, `doDropPayment`, `doWebCheckoutPayment`, `doSubscriptionPayment`, `setCallback` — unchanged from the wrapper's existing 5 methods. No new methods, no removed methods.
- **Added APIs**: none.
- **Newly deprecated APIs**: upstream 1.1.0 added `/** @deprecated Use doWebCheckoutPayment instead. */` directly above `doDropPayment` in `dist/CFPaymentGateway.d.ts` and `dist/CFPaymentGateway.js` (absent in 1.0.12). Mirrored this by adding a `@deprecated` JSDoc line to `CFPaymentGateway.doDropPayment` in the wrapper, per this repo's backwards-compatibility rule (method kept, not removed).
- **Type changes**: none — `CFDropCheckoutPayment`, `CFWebCheckoutPayment`, `CFUPIIntentCheckoutPayment`, `CFSubscriptionPayment`, `CFCallback`, theme/session field shapes all still match upstream's native Android (`src/android/CFPaymentGateway.java`) and README payload examples.
- Source used: `https://registry.npmjs.org/cordova-plugin-cashfree-pg` tarball for `1.1.0` (and `1.0.12` for diffing), plus `README.md` from the same package.

## Test plan
- [x] `npx eslint src/@awesome-cordova-plugins/plugins/cashfree-pg/index.ts` — clean
- [x] `npx tsc -p tsconfig.json --noEmit 2>&1 | grep "plugins/cashfree-pg/"` — no output for this plugin (repo-wide pre-existing `Cannot find module '@awesome-cordova-plugins/core'` error affects all 257 plugin files in this worktree due to missing built core package; not introduced by this change)
