### PR TITLE
feat(appsflyer): add missing v6.18.1 SDK methods

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/appsflyer/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/appsflyer/index.ts
@@ -36,6 +36,16 @@ export interface AppsflyerOptions {
    * time for the sdk to wait before launch - IOS 14 ONLY!
    */
   waitForATTUserAuthorization?: number;
+
+  /**
+   * For iOS only, to test uninstall in Sandbox environment
+   */
+  useUninstallSandbox?: boolean;
+
+  /**
+   * Prevents the SDK from sending the launch request after calling initSdk(...). When using this property, the app needs to manually trigger the startSdk() API to report the app launch. default=true
+   */
+  shouldStartSdk?: boolean;
 }
 
 export interface AppsflyerEvent {
@@ -48,6 +58,87 @@ export interface AppsflyerInviteOptions {
   userParams?: {
     [x: string]: any;
   };
+}
+
+export interface AppsflyerConsent {
+  /**
+   * Indicates whether GDPR regulations apply to the user. Also serves as a flag for compliance with relevant aspects of DMA regulations.
+   */
+  isUserSubjectToGDPR: boolean | null;
+
+  /**
+   * Indicates whether the user has consented to use their data for advertising purposes.
+   */
+  hasConsentForDataUsage: boolean | null;
+
+  /**
+   * Indicates whether the user has consented to use their data for personalized advertising.
+   */
+  hasConsentForAdsPersonalization: boolean | null;
+
+  /**
+   * Indicates whether the user has provided consent for the storage of their advertising data.
+   */
+  hasConsentForAdStorage: boolean | null;
+}
+
+export interface AppsflyerPurchaseDetails {
+  /**
+   * The purchase type: "subscription" or "one_time_purchase"
+   */
+  purchaseType: string;
+
+  /**
+   * The purchase token from Google Play Store (Android) or transaction ID (iOS)
+   */
+  purchaseToken: string;
+
+  /**
+   * The product identifier
+   */
+  productId: string;
+}
+
+/**
+ * Mediation network values accepted by logAdRevenue's AppsflyerAdRevenueData.mediationNetwork field.
+ */
+export enum AppsflyerMediationNetwork {
+  IRONSOURCE = 'ironsource',
+  APPLOVIN_MAX = 'applovinmax',
+  GOOGLE_ADMOB = 'googleadmob',
+  FYBER = 'fyber',
+  APPODEAL = 'appodeal',
+  ADMOST = 'Admost',
+  TOPON = 'Topon',
+  TRADPLUS = 'Tradplus',
+  YANDEX = 'Yandex',
+  CHARTBOOST = 'chartboost',
+  UNITY = 'Unity',
+  TOPON_PTE = 'toponpte',
+  CUSTOM_MEDIATION = 'customMediation',
+  DIRECT_MONETIZATION_NETWORK = 'directMonetizationNetwork',
+}
+
+export interface AppsflyerAdRevenueData {
+  /**
+   * The monetization network name
+   */
+  monetizationNetwork: string;
+
+  /**
+   * The mediation network used
+   */
+  mediationNetwork: AppsflyerMediationNetwork;
+
+  /**
+   * ISO 4217 currency code
+   */
+  currencyIso4217Code: string;
+
+  /**
+   * The ad revenue amount
+   */
+  revenue: number;
 }
 
 /**
@@ -71,6 +162,9 @@ export interface AppsflyerInviteOptions {
  * AppsflyerOptions
  * AppsflyerEvent
  * AppsflyerInviteOptions
+ * AppsflyerConsent
+ * AppsflyerPurchaseDetails
+ * AppsflyerAdRevenueData
  */
 @Plugin({
   pluginName: 'Appsflyer',
@@ -209,4 +303,276 @@ export class Appsflyer extends AwesomeCordovaNativePlugin {
    */
   @Cordova({ sync: true })
   logCrossPromotionAndOpenStore(appId: string, campaign: string, options: object): void {}
+
+  /**
+   * Starts the SDK. Must call initSdk first in order to make this work. Used together with the AppsflyerOptions.shouldStartSdk option.
+   */
+  @Cordova({ sync: true })
+  startSdk(): void {}
+
+  /**
+   * Register Unified deep link listener. Must be called before initSdk() and it overrides registerOnAppOpenAttribution.
+   *
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  registerDeepLink(): Promise<any> {
+    return;
+  }
+
+  /**
+   * Set the currency code used for in-app purchase events.
+   *
+   * @param {string} currencyId ISO 4217 Currency Codes, default 'USD'
+   */
+  @Cordova({ sync: true })
+  setCurrencyCode(currencyId: string): void {}
+
+  /**
+   * Get the current SDK version
+   *
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  getSdkVersion(): Promise<any> {
+    return;
+  }
+
+  /**
+   * @deprecated deprecated since 6.4.0. Use setSharingFilterForPartners instead
+   * Used by advertisers to exclude all networks/integrated partners from getting data
+   */
+  @Cordova({ sync: true })
+  setSharingFilterForAllPartners(): void {}
+
+  /**
+   * @deprecated deprecated since 6.4.0. Use setSharingFilterForPartners instead
+   * Used by advertisers to exclude specified networks/integrated partners from getting data
+   *
+   * @param {string[]} networks Array of partners that need to be excluded
+   */
+  @Cordova({ sync: true })
+  setSharingFilter(networks: string[]): void {}
+
+  /**
+   * Used by advertisers to exclude specified networks/integrated partners from getting data
+   *
+   * @param {string[]} networks Array of partners that need to be excluded
+   */
+  @Cordova({ sync: true })
+  setSharingFilterForPartners(networks: string[]): void {}
+
+  /**
+   * @deprecated Will be removed in the future. Please use validateAndLogInAppPurchaseV2.
+   * Receipt validation is a secure mechanism whereby the payment platform (e.g. Apple or Google) validates that an in-app purchase indeed occurred as reported.
+   *
+   * @param {AppsflyerEvent} purchaseInfo In-App Purchase parameters
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  validateAndLogInAppPurchase(purchaseInfo: AppsflyerEvent): Promise<any> {
+    return;
+  }
+
+  /**
+   * Receipt validation is a secure mechanism whereby the payment platform (e.g. Apple or Google) validates that an in-app purchase indeed occurred as reported. This method uses V2 API.
+   *
+   * @param {AppsflyerPurchaseDetails} purchaseDetails Purchase details object containing productId, purchaseToken and purchaseType
+   * @param {AppsflyerEvent} additionalParameters Additional parameters to include with the purchase event (optional)
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  validateAndLogInAppPurchaseV2(
+    purchaseDetails: AppsflyerPurchaseDetails,
+    additionalParameters?: AppsflyerEvent
+  ): Promise<any> {
+    return;
+  }
+
+  /**
+   * In app purchase receipt validation Apple environment (production or sandbox)
+   *
+   * @param {boolean} isSandbox true if In app purchase is done with sandbox
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  setUseReceiptValidationSandbox(isSandbox: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * (iOS only) AppsFlyer SDK dynamically loads the Apple iAd.framework. This framework is required to record and measure the performance of Apple Search Ads in your app. If you don't want AppsFlyer to dynamically load this framework, set this property to true.
+   *
+   * @param {boolean} collectASA If you don't want AppsFlyer to dynamically load iAd.framework, set this property to true
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  disableCollectASA(collectASA: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Disable collection of Apple, Google, Amazon and Open advertising ids (IDFA, GAID, AAID, OAID).
+   *
+   * @param {boolean} disableAdvertisingIdentifier Disable collection of advertising ids
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  setDisableAdvertisingIdentifier(disableAdvertisingIdentifier: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Set Onelink custom/branded domains. Use this API during the SDK Initialization to indicate branded domains.
+   *
+   * @param {string[]} domains String array of branded domains
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  setOneLinkCustomDomains(domains: string[]): Promise<any> {
+    return;
+  }
+
+  /**
+   * Support deferred deep linking from Facebook Ads. Use this API before initSdk().
+   *
+   * @param {boolean} isEnabled enable support deferred deep linking from Facebook Ads
+   */
+  @Cordova({ sync: true })
+  enableFacebookDeferredApplinks(isEnabled: boolean): void {}
+
+  /**
+   * Set user emails for FB Advanced Matching
+   *
+   * @param {string[]} emails String array of emails
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  setUserEmails(emails: string[]): Promise<any> {
+    return;
+  }
+
+  /**
+   * Set phone number for FB Advanced Matching
+   *
+   * @param {string} phoneNumber String phone number
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  setPhoneNumber(phoneNumber: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Set custom host prefix and host name
+   *
+   * @param {string} hostPrefix host prefix
+   * @param {string} hostName host name
+   */
+  @Cordova({ sync: true })
+  setHost(hostPrefix: string, hostName: string): void {}
+
+  /**
+   * Provides app owners with a flexible interface for configuring how deep links are extracted from push notification payloads. Must be called before initSdk().
+   *
+   * @param {string[]} path strings array of the path
+   */
+  @Cordova({ sync: true })
+  addPushNotificationDeepLinkPath(path: string[]): void {}
+
+  /**
+   * Use this API to get the OneLink from click domains that launch the app. Make sure to call this API before SDK initialization.
+   *
+   * @param {string[]} urls strings array of domains
+   */
+  @Cordova({ sync: true })
+  setResolveDeepLinkURLs(urls: string[]): void {}
+
+  /**
+   * Enable or disable SKAD support. Set true if you want to disable it. Must be called before initSdk() and for iOS only.
+   *
+   * @param {boolean} isDisabled disable or enable SKAD support
+   */
+  @Cordova({ sync: true })
+  disableSKAD(isDisabled: boolean): void {}
+
+  /**
+   * Set the language of the device. The data will be displayed in Raw Data Reports. Must be called before initSdk() and for iOS only.
+   *
+   * @param {string} language The device language
+   */
+  @Cordova({ sync: true })
+  setCurrentDeviceLanguage(language: string): void {}
+
+  /**
+   * Allows you to add custom data to events sent from the SDK. Typically used to integrate on the SDK level with several external partner platforms.
+   *
+   * @param {AppsflyerEvent} additionalData custom data
+   */
+  @Cordova({ sync: true })
+  setAdditionalData(additionalData: AppsflyerEvent): void {}
+
+  /**
+   * Allows sending custom data for partner integration purposes.
+   *
+   * @param {string} partnerId ID of the partner (usually suffixed with "_int")
+   * @param {AppsflyerEvent} data Customer data, depends on the integration configuration with the specific partner
+   */
+  @Cordova({ sync: true })
+  setPartnerData(partnerId: string, data: AppsflyerEvent): void {}
+
+  /**
+   * Measure and get data from push-notification campaigns.
+   *
+   * @param {AppsflyerEvent} pushData JSON object contains the push data
+   */
+  @Cordova({ sync: true })
+  sendPushNotificationData(pushData: AppsflyerEvent): void {}
+
+  /**
+   * Use to opt-out of collecting the network operator name (carrier) and sim operator name from the device.
+   *
+   * @param {boolean} disable Defaults to false
+   */
+  @Cordova({ sync: true })
+  setDisableNetworkData(disable: boolean): void {}
+
+  /**
+   * Set consent fields manually (e.g. by prompting user and collecting results). Use this API to provide the consent data directly to the SDK when GDPR applies to the user and your app does not use a CMP compatible with TCF v2.2.
+   *
+   * @param {AppsflyerConsent} appsFlyerConsent Consent data
+   */
+  @Cordova({ sync: true })
+  setConsentData(appsFlyerConsent: AppsflyerConsent): void {}
+
+  /**
+   * Instruct the SDK to collect the TCF data from the device.
+   *
+   * @param {boolean} enable enable/disable TCF data collection
+   */
+  @Cordova({ sync: true })
+  enableTCFDataCollection(enable: boolean): void {}
+
+  /**
+   * Log ad revenue event.
+   *
+   * @param {AppsflyerAdRevenueData} adRevenueData the ad revenue data
+   * @param {AppsflyerEvent} additionalParameters additional params data (optional)
+   */
+  @Cordova({ sync: true })
+  logAdRevenue(adRevenueData: AppsflyerAdRevenueData, additionalParameters?: AppsflyerEvent): void {}
+
+  /**
+   * (Android only) Disables App Set ID collection (enabled by default).
+   */
+  @Cordova({ sync: true })
+  disableAppSetId(): void {}
+
+  /**
+   * (iOS) Log deep linking. Add a function 'handleOpenUrl' to your root and call this to track deeplinks with AppsFlyer attribution data.
+   *
+   * @param {string} url the opened url
+   */
+  @Cordova({ sync: true })
+  handleOpenUrl(url: string): void {}
 }


### PR DESCRIPTION
## Summary

Compared the wrapper (`src/@awesome-cordova-plugins/plugins/appsflyer/index.ts`, last touched 2026-03-21) against `cordova-plugin-appsflyer-sdk@6.18.1` (latest, released 2026-06-30) — specifically `www/appsflyer.js` and `docs/API.md` from the upstream repo. Source used: https://cdn.jsdelivr.net/npm/cordova-plugin-appsflyer-sdk@6.18.1/www/appsflyer.js and https://raw.githubusercontent.com/AppsFlyerSDK/cordova-plugin-appsflyer-sdk/master/docs/API.md.

The wrapper only covered a small subset of the plugin's JS bridge; the rest was added, all backward compatible.

### Added APIs
- `startSdk()`
- `registerDeepLink()`
- `setCurrencyCode(currencyId)`
- `getSdkVersion()`
- `setSharingFilterForPartners(networks)`
- `setSharingFilter(networks)` — deprecated upstream since 6.4.0, use `setSharingFilterForPartners`
- `setSharingFilterForAllPartners()` — deprecated upstream since 6.4.0, use `setSharingFilterForPartners`
- `validateAndLogInAppPurchase(purchaseInfo)` — deprecated upstream, use `validateAndLogInAppPurchaseV2`
- `validateAndLogInAppPurchaseV2(purchaseDetails, additionalParameters?)`
- `setUseReceiptValidationSandbox(isSandbox)`
- `disableCollectASA(collectASA)`
- `setDisableAdvertisingIdentifier(disableAdvertisingIdentifier)`
- `setOneLinkCustomDomains(domains)`
- `enableFacebookDeferredApplinks(isEnabled)`
- `setUserEmails(emails)`
- `setPhoneNumber(phoneNumber)`
- `setHost(hostPrefix, hostName)`
- `addPushNotificationDeepLinkPath(path)`
- `setResolveDeepLinkURLs(urls)`
- `disableSKAD(isDisabled)`
- `setCurrentDeviceLanguage(language)`
- `setAdditionalData(additionalData)`
- `setPartnerData(partnerId, data)`
- `sendPushNotificationData(pushData)`
- `setDisableNetworkData(disable)`
- `setConsentData(appsFlyerConsent)`
- `enableTCFDataCollection(enable)`
- `logAdRevenue(adRevenueData, additionalParameters?)`
- `disableAppSetId()`
- `handleOpenUrl(url)`

New supporting types: `AppsflyerConsent`, `AppsflyerPurchaseDetails`, `AppsflyerAdRevenueData`, `AppsflyerMediationNetwork` enum. Also added optional `useUninstallSandbox` and `shouldStartSdk` fields to the existing `AppsflyerOptions` interface (additive, non-breaking).

### Newly deprecated APIs
- `setSharingFilter` (upstream deprecated since 6.4.0)
- `setSharingFilterForAllPartners` (upstream deprecated since 6.4.0)
- `validateAndLogInAppPurchase` (upstream deprecated, superseded by V2)

These already exist as functioning upstream methods (not removed), so they were added with `@deprecated` JSDoc rather than omitted.

### Potentially breaking
None. No existing exported method, interface, property, or enum was removed, renamed, or retyped.

### Not changed
`enableUninstallTracking` (already marked `@deprecated` in the wrapper) was kept as-is — it no longer exists in the current upstream JS bridge, consistent with its pre-existing deprecation.

## Test plan
- [x] `npx eslint src/@awesome-cordova-plugins/plugins/appsflyer/index.ts` — 0 errors (17 pre-existing-style `no-explicit-any` warnings, consistent with rest of file)
- [x] `npx tsc -p tsconfig.json --noEmit 2>&1 | grep "plugins/appsflyer/"` — no output
