### PR TITLE
feat(onesignal): add OneSignal v5 user-centric API, deprecate removed v2 flat API

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/onesignal/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/onesignal/index.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Cordova, AwesomeCordovaNativePlugin, Plugin } from '@awesome-cordova-plugins/core';
+import { Cordova, CordovaProperty, AwesomeCordovaNativePlugin, Plugin } from '@awesome-cordova-plugins/core';
 import { Observable } from 'rxjs';
 
 export interface OSNotification {
@@ -326,10 +326,262 @@ export interface OSInAppMessageAction {
 }
 
 /**
+ * Logging levels used by `OneSignalDebug`. Available since onesignal-cordova-plugin v5.0.0.
+ */
+export enum LogLevel {
+  None = 0,
+  Fatal = 1,
+  Error = 2,
+  Warn = 3,
+  Info = 4,
+  Debug = 5,
+  Verbose = 6,
+}
+
+/**
+ * iOS** - Native push notification permission state returned by `OneSignalNotifications.permissionNative`.
+ * Available since onesignal-cordova-plugin v5.0.0.
+ */
+export enum OSNotificationPermission {
+  NotDetermined = 0,
+  Denied = 1,
+  Authorized = 2,
+  /**
+   * Only available in iOS 12+.
+   */
+  Provisional = 3,
+  /**
+   * Only available in iOS 14+.
+   */
+  Ephemeral = 4,
+}
+
+/**
+ * Options for `OneSignalLiveActivities.setupDefault`.
+ */
+export interface LiveActivitySetupOptions {
+  /**
+   * When true, OneSignal will listen for pushToStart tokens for the `OneSignalLiveActivityAttributes` structure.
+   */
+  enablePushToStart: boolean;
+  /**
+   * When true, OneSignal will listen for pushToUpdate tokens for each started live activity that uses the
+   * `OneSignalLiveActivityAttributes` structure.
+   */
+  enablePushToUpdate: boolean;
+}
+
+/**
+ * Snapshot of the current user identifiers. See `OneSignalUser.addEventListener`.
+ */
+export interface UserState {
+  onesignalId?: string;
+  externalId?: string;
+}
+
+/**
+ * Payload delivered to `OneSignalUser.addEventListener('change', ...)`.
+ */
+export interface UserChangedState {
+  current: UserState;
+}
+
+/**
+ * Snapshot of the current push subscription. See `OneSignalUserPushSubscription.addEventListener`.
+ */
+export interface PushSubscriptionState {
+  id?: string;
+  token?: string;
+  optedIn: boolean;
+}
+
+/**
+ * Payload delivered to `OneSignalUserPushSubscription.addEventListener('change', ...)`.
+ */
+export interface PushSubscriptionChangedState {
+  previous: PushSubscriptionState;
+  current: PushSubscriptionState;
+}
+
+/**
+ * An In-App Message instance. See the `OneSignalInAppMessages` event payloads.
+ */
+export interface OSInAppMessage {
+  /**
+   * The In-App Message's UUID.
+   */
+  messageId: string;
+}
+
+/**
+ * Type of URL opened by an In-App Message action.
+ */
+export type InAppMessageActionUrlType = 'browser' | 'webview' | 'replacement';
+
+/**
+ * Result of an In-App Message action element (button or image) being tapped on.
+ */
+export interface InAppMessageClickResult {
+  /**
+   * Whether tapping the action closes the In-App Message.
+   */
+  closingMessage: boolean;
+  /**
+   * An optional click name defined for the action element.
+   */
+  actionId?: string;
+  /**
+   * An optional URL that opens when the action takes place.
+   */
+  url?: string;
+  urlTarget?: InAppMessageActionUrlType;
+}
+
+/**
+ * Payload delivered to `OneSignalInAppMessages.addEventListener('click', ...)`.
+ */
+export interface InAppMessageClickEvent {
+  message: OSInAppMessage;
+  result: InAppMessageClickResult;
+}
+
+/**
+ * Payload delivered to `OneSignalInAppMessages.addEventListener('willDisplay', ...)`.
+ */
+export interface InAppMessageWillDisplayEvent {
+  message: OSInAppMessage;
+}
+
+/**
+ * Payload delivered to `OneSignalInAppMessages.addEventListener('didDisplay', ...)`.
+ */
+export interface InAppMessageDidDisplayEvent {
+  message: OSInAppMessage;
+}
+
+/**
+ * Payload delivered to `OneSignalInAppMessages.addEventListener('willDismiss', ...)`.
+ */
+export interface InAppMessageWillDismissEvent {
+  message: OSInAppMessage;
+}
+
+/**
+ * Payload delivered to `OneSignalInAppMessages.addEventListener('didDismiss', ...)`.
+ */
+export interface InAppMessageDidDismissEvent {
+  message: OSInAppMessage;
+}
+
+/**
+ * Event names supported by `OneSignalInAppMessages.addEventListener`.
+ */
+export type InAppMessageEventName = 'click' | 'willDisplay' | 'didDisplay' | 'willDismiss' | 'didDismiss';
+
+/**
+ * Maps `InAppMessageEventName` to its corresponding event payload type.
+ */
+export interface InAppMessageEventTypeMap {
+  click: InAppMessageClickEvent;
+  willDisplay: InAppMessageWillDisplayEvent;
+  didDisplay: InAppMessageDidDisplayEvent;
+  willDismiss: InAppMessageWillDismissEvent;
+  didDismiss: InAppMessageDidDismissEvent;
+}
+
+/**
+ * A received push notification, as delivered by the user-centric SDK (onesignal-cordova-plugin v5+). Distinct from
+ * the legacy `OSNotification` interface, which is kept for the deprecated flat API.
+ */
+export interface OneSignalNotification {
+  body: string;
+  sound?: string;
+  title?: string;
+  launchURL?: string;
+  rawPayload: object;
+  actionButtons?: object[];
+  additionalData: object;
+  notificationId: string;
+  groupKey?: string;
+  groupMessage?: string;
+  groupedNotifications?: object[];
+  ledColor?: string;
+  priority?: number;
+  smallIcon?: string;
+  largeIcon?: string;
+  bigPicture?: string;
+  collapseId?: string;
+  fromProjectNumber?: string;
+  smallIconAccentColor?: string;
+  lockScreenVisibility?: string;
+  androidNotificationId?: number;
+  badge?: string;
+  badgeIncrement?: string;
+  category?: string;
+  threadId?: string;
+  subtitle?: string;
+  templateId?: string;
+  templateName?: string;
+  attachments?: object;
+  mutableContent?: boolean;
+  contentAvailable?: string;
+  relevanceScore?: number;
+  interruptionLevel?: string;
+}
+
+export interface NotificationClickResult {
+  actionId?: string;
+  url?: string;
+}
+
+/**
+ * Payload delivered to `OneSignalNotifications.addEventListener('click', ...)`.
+ */
+export interface NotificationClickEvent {
+  result: NotificationClickResult;
+  notification: OneSignalNotification;
+}
+
+/**
+ * Payload delivered to `OneSignalNotifications.addEventListener('foregroundWillDisplay', ...)`.
+ */
+export interface NotificationWillDisplayEvent {
+  /**
+   * Call this to prevent OneSignal from displaying the notification automatically. This method can be called up to
+   * two times with `false` and then `true`, if processing time is needed. Typically this is only possible within a
+   * short time-frame (~30 seconds) after the notification is received on the device.
+   *
+   * @param discard If `true`, dismisses the notification with no possibility of displaying it in the future.
+   */
+  preventDefault(discard?: boolean): void;
+  getNotification(): OneSignalNotification;
+}
+
+/**
+ * Event names supported by `OneSignalNotifications.addEventListener`.
+ */
+export type NotificationEventName = 'click' | 'foregroundWillDisplay' | 'permissionChange';
+
+/**
+ * Maps `NotificationEventName` to its corresponding event payload type.
+ */
+export interface NotificationEventTypeMap {
+  click: NotificationClickEvent;
+  foregroundWillDisplay: NotificationWillDisplayEvent;
+  permissionChange: boolean;
+}
+
+/**
  * @name OneSignal
  * @description
  * The OneSignal plugin is an client implementation for using the [OneSignal](https://onesignal.com/) Service.
  * OneSignal is a simple implementation for delivering push notifications.
+ *
+ * As of onesignal-cordova-plugin v5.0.0, OneSignal moved to a user-centric API split across the `OneSignal`,
+ * `OneSignalUser`, `OneSignalUserPushSubscription`, `OneSignalNotifications`, `OneSignalSession`, `OneSignalLocation`,
+ * `OneSignalInAppMessages`, `OneSignalDebug` and `OneSignalLiveActivities` injectables in this package. The flat
+ * methods below (`startInit`, `sendTag`, etc.) were removed upstream in v5.0.0 and are kept here only for backwards
+ * compatibility; they are marked `@deprecated` with their v5+ replacement.
  *
  * Please view the official [OneSignal Ionic SDK Installation](https://documentation.onesignal.com/docs/ionic-sdk-setup) guide
  * for more information.
@@ -397,25 +649,25 @@ export interface OSInAppMessageAction {
  * `$ chmod +x hooks/copy_android_notification_icons.js`
  * @usage
  * ```typescript
- * import { OneSignal } from '@awesome-cordova-plugins/onesignal/ngx';
+ * import { OneSignal, OneSignalNotifications, OneSignalUser } from '@awesome-cordova-plugins/onesignal/ngx';
  *
- * constructor(private oneSignal: OneSignal) { }
+ * constructor(
+ *   private oneSignal: OneSignal,
+ *   private oneSignalNotifications: OneSignalNotifications,
+ *   private oneSignalUser: OneSignalUser
+ * ) { }
  *
  * ...
  *
- * this.oneSignal.startInit('b2f7f966-d8cc-11e4-bed1-df8f05be55ba', '703322744261');
+ * this.oneSignal.initialize('b2f7f966-d8cc-11e4-bed1-df8f05be55ba');
  *
- * this.oneSignal.inFocusDisplaying(this.oneSignal.OSInFocusDisplayOption.InAppAlert);
- *
- * this.oneSignal.handleNotificationReceived().subscribe(() => {
- *  // do something when notification is received
- * });
- *
- * this.oneSignal.handleNotificationOpened().subscribe(() => {
+ * this.oneSignalNotifications.addEventListener('click', (event) => {
  *   // do something when a notification is opened
  * });
  *
- * this.oneSignal.endInit();
+ * this.oneSignalNotifications.requestPermission(true);
+ *
+ * this.oneSignalUser.addTag('key', 'value');
  * ```
  * @interfaces
  * OSNotification
@@ -427,13 +679,28 @@ export interface OSInAppMessageAction {
  * OSNotificationOpenedResult
  * OSActionType
  * OSInAppMessageAction
+ * LogLevel
+ * OSNotificationPermission
+ * LiveActivitySetupOptions
+ * UserState
+ * UserChangedState
+ * PushSubscriptionState
+ * PushSubscriptionChangedState
+ * OSInAppMessage
+ * InAppMessageClickResult
+ * InAppMessageClickEvent
+ * InAppMessageEventTypeMap
+ * OneSignalNotification
+ * NotificationClickEvent
+ * NotificationWillDisplayEvent
+ * NotificationEventTypeMap
  */
 @Plugin({
   pluginName: 'OneSignal',
   plugin: 'onesignal-cordova-plugin',
-  pluginRef: 'plugins.OneSignal',
+  pluginRef: 'OneSignal',
   repo: 'https://github.com/OneSignal/OneSignal-Cordova-SDK',
-  platforms: ['Amazon Fire OS', 'Android', 'iOS', 'Windows'],
+  platforms: ['Android', 'iOS'],
 })
 @Injectable()
 export class OneSignal extends AwesomeCordovaNativePlugin {
@@ -441,6 +708,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * constants to use in inFocusDisplaying()
    *
    * @hidden
+   * @deprecated `inFocusDisplaying` was removed in onesignal-cordova-plugin v5.0.0. Use
+   * `OneSignalNotifications.addEventListener('foregroundWillDisplay', ...)` instead.
    */
   OSInFocusDisplayOption = {
     None: 0,
@@ -449,8 +718,66 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   };
 
   /**
+   * Initializes the OneSignal SDK. This should be called during startup of the application.
+   *
+   * @param {string} appId Your OneSignal app id
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  initialize(appId: string): void {
+    return;
+  }
+
+  /**
+   * Login to OneSignal under the user identified by the `externalId` provided. The act of logging a user into the
+   * OneSignal SDK will switch the user context to that specific user.
+   *
+   * @param {string} externalId
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  login(externalId: string): void {
+    return;
+  }
+
+  /**
+   * Logout the user previously logged in via `login`. The user context now references a new device-scoped user.
+   *
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  logout(): void {
+    return;
+  }
+
+  /**
+   * Determines whether a user must consent to privacy prior to their user data being sent up to OneSignal. This
+   * should be set to `true` prior to the invocation of `initialize` to ensure compliance.
+   *
+   * @param {boolean} required
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  setConsentRequired(required: boolean): void {
+    return;
+  }
+
+  /**
+   * Indicates whether privacy consent has been granted. This field is only relevant when the application has opted
+   * into data privacy protections.
+   *
+   * @param {boolean} granted
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  setConsentGiven(granted: boolean): void {
+    return;
+  }
+
+  /**
    * Start the initialization process. Once you are done configuring OneSignal, call the `endInit` function.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `initialize` instead.
    * @param {string} appId Your OneSignal app id
    * @param {string} googleProjectNumber **ANDROID** - your Google project number; only required for Android GCM/FCM pushes.
    * @returns {any}
@@ -463,6 +790,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Callback to run when a notification is received, whether it was displayed or not.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use
+   * `OneSignalNotifications.addEventListener('foregroundWillDisplay', ...)` instead.
    * @returns {Observable<OneSignalReceivedNotification>}
    */
   @Cordova({
@@ -477,6 +806,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * center (**iOS**), or when closing an Alert notification shown in the app (if InAppAlert is enabled in
    * inFocusDisplaying).
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use
+   * `OneSignalNotifications.addEventListener('click', ...)` instead.
    * @returns {Observable<OneSignalOpenedNotification>}
    */
   @Cordova({
@@ -489,6 +820,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Use to process an In-App Message the user just tapped on.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use
+   * `OneSignalInAppMessages.addEventListener('click', ...)` instead.
    * @returns {Observable<OSInAppMessageAction>}
    */
   @Cordova({
@@ -501,6 +834,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * iOS** - Settings for iOS apps
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. No direct replacement.
    * @param settings
    *  kOSSettingsKeyAutoPrompt: boolean = true
    *  Auto prompt user for notification permissions.
@@ -522,6 +856,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Must be called after `startInit` to complete initialization of OneSignal.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. `initialize` no longer requires a matching `endInit` call.
    * @returns {any}
    */
   @Cordova({ sync: true })
@@ -532,6 +867,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Prompt the user for notification permissions. Callback fires as soon as the user accepts or declines notifications.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalNotifications.requestPermission` instead.
    * @returns {Promise<boolean>}
    */
   @Cordova({
@@ -546,6 +882,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    *
    * Quirk**: You must wait for `getTags` to resolve before calling it again, as the plugin will only process the last method call and discard any previous ones.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalUser.getTags` instead.
    * @returns {Promise<any>} Returns a Promise that resolves when tags are recieved.
    */
   @Cordova()
@@ -557,6 +894,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * Lets you retrieve the OneSignal user id and device token.
    * Your handler is called after the device is successfully registered with OneSignal.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalUser.getOnesignalId` and
+   * `OneSignalUserPushSubscription.getIdAsync`/`getTokenAsync` instead.
    * @returns {Promise<Object>} Returns a Promise that resolves if the device was successfully registered.
    *
    *  userId {string} OneSignal userId is a UUID formatted string. (unique per device per app)
@@ -572,6 +911,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * Tag a user based on an app event of your choosing so later you can create segments on [onesignal.com](https://onesignal.com/) to target these users.
    * Recommend using sendTags over sendTag if you need to set more than one tag on a user at a time.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalUser.addTag` instead.
    * @param {string} Key of your choosing to create or update.
    * @param {string} Value to set on the key. NOTE: Passing in a blank String deletes the key, you can also call deleteTag.
    * @param key
@@ -584,6 +924,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * Tag a user based on an app event of your choosing so later you can create segments on [onesignal.com](https://onesignal.com/) to target these users.
    * Recommend using sendTags over sendTag if you need to set more than one tag on a user at a time.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalUser.addTags` instead.
    * @param {string} Pass a json object with key/value pairs like: {key: "value", key2: "value2"}
    * @param json
    */
@@ -593,6 +934,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Deletes a tag that was previously set on a user with `sendTag` or `sendTags`. Use `deleteTags` if you need to delete more than one.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalUser.removeTag` instead.
    * @param {string} Key to remove.
    * @param key
    */
@@ -602,6 +944,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Deletes tags that were previously set on a user with `sendTag` or `sendTags`.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalUser.removeTags` instead.
    * @param {string[]} Keys to remove.
    * @param keys
    */
@@ -611,6 +954,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Call this when you would like to prompt an iOS user to accept push notifications with the default system prompt.
    * Only works if you set `kOSSettingsAutoPrompt` to `false` in `iOSSettings`
+   *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalNotifications.requestPermission` instead.
    */
   @Cordova({ sync: true })
   registerForPushNotifications(): void {}
@@ -622,6 +967,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * By default OneSignal always vibrates the device when a notification is displayed unless the device is in a total silent mode.
    * Passing false means that the device will only vibrate lightly when the device is in it's vibrate only mode.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. No direct replacement.
    * @param {boolean} false to disable vibrate, true to re-enable it.
    * @param enable
    */
@@ -635,6 +981,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * By default OneSignal plays the system's default notification sound when the device's notification system volume is turned on.
    * Passing false means that the device will only vibrate unless the device is set to a total silent mode.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. No direct replacement.
    * @param {boolean} false to disable sound, true to re-enable it.
    * @param enable
    */
@@ -645,6 +992,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    *
    * Setting to control how OneSignal notifications will be shown when one is received while your app is in focus. By default this is set to inAppAlert, which can be helpful during development.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use
+   * `OneSignalNotifications.addEventListener('foregroundWillDisplay', ...)` and `NotificationWillDisplayEvent.preventDefault` instead.
    * @param {DisplayType} displayOption
    * @returns {any}
    */
@@ -657,6 +1006,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * You can call this method with false to opt users out of receiving all notifications through OneSignal.
    * You can pass true later to opt users back into notifications.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalUserPushSubscription.optIn`/`optOut` instead.
    * @param {boolean} enable
    */
   @Cordova({ sync: true })
@@ -665,6 +1015,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Get the current notification and permission state. Returns a OSPermissionSubscriptionState type described below.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalNotifications.getPermissionAsync` and
+   * `OneSignalUserPushSubscription.getOptedInAsync` instead.
    * @returns {Promise<OSPermissionSubscriptionState>}
    */
   @Cordova()
@@ -674,6 +1026,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
 
   /**
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Send notifications via the OneSignal REST API instead.
    * @param {notificationObj} Parameters see POST [documentation](https://documentation.onesignal.com/v2.0/docs/notifications-create-notification)
    * @param notificationObj
    * @returns {Promise<any>} Returns a Promise that resolves if the notification was send successfully.
@@ -686,6 +1039,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Cancels a single OneSignal notification based on its Android notification integer id. Use instead of NotificationManager.cancel(id); otherwise the notification will be restored when your app is restarted.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalNotifications.removeNotification` instead.
    * @param notificationId {string}
    */
   @Cordova({ sync: true })
@@ -693,12 +1047,15 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
 
   /**
    * Prompts the user for location permission to allow geotagging based on the "Location radius" filter on the OneSignal dashboard.
+   *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalLocation.requestPermission` instead.
    */
   @Cordova({ sync: true })
   promptLocation(): void {}
 
   /**
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalUser.addEmail` instead.
    * @param email {string}
    */
   @Cordova({ sync: true })
@@ -710,6 +1067,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    *
    * The higher the value the more information is shown.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalDebug.setLogLevel`/`setAlertLevel` instead.
    * @param {loglevel} contains two properties: logLevel (for console logging) and visualLevel (for dialog messages)
    * @param logLevel
    * @param logLevel.logLevel
@@ -721,6 +1079,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Disable or enable location collection (Defaults to enabled) if your app has location permission.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalLocation.setShared` instead.
    * @param shared {boolean}
    */
   @Cordova({ sync: true })
@@ -733,6 +1092,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * - The user accepting or declining the permission prompt
    * - Enabling/disabling notifications for your app in the device Settings after returning to your app.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use
+   * `OneSignalNotifications.addEventListener('permissionChange', ...)` instead.
    * @returns {Observable<any>}
    */
   @Cordova({
@@ -750,6 +1111,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * - OneSignal.setSubscription is called
    * - User disables or enables notifications
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use
+   * `OneSignalUserPushSubscription.addEventListener('change', ...)` instead.
    * @returns {Observable<any>}
    */
   @Cordova({
@@ -762,6 +1125,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Clears all OneSignal notifications
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalUser.addEmail` instead.
    * @param email
    * @param emailAuthToken
    */
@@ -772,6 +1136,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
 
   /**
    * If your app implements logout functionality, you can call logoutEmail to dissociate the email from the device
+   *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalUser.removeEmail` instead.
    */
   @Cordova()
   logoutEmail(): Promise<any> {
@@ -786,6 +1152,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * - OneSignal.setSubscription is called
    * - User disables or enables notifications
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use
+   * `OneSignalUser.addEventListener('change', ...)` instead.
    * @returns {Observable<any>}
    */
   @Cordova({
@@ -797,6 +1165,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
 
   /**
    * Clears all OneSignal notifications
+   *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalNotifications.clearAll` instead.
    */
   @Cordova({ sync: true })
   clearOneSignalNotifications(): void {}
@@ -805,6 +1175,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * Allows you to delay the initialization of the SDK until the user provides privacy consent.
    * The SDK will not be fully initialized until the provideUserConsent(true) method is called.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `setConsentRequired` instead.
    * @param {boolean} required
    */
   @Cordova()
@@ -814,6 +1185,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * If your application is set to require the user's privacy consent, you can provide this consent using this method.
    * Until you call provideUserConsent(true), the SDK will not fully initialize and will not send any data to OneSignal.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `setConsentGiven` instead.
    * @param {boolean} granted
    */
   @Cordova()
@@ -822,6 +1194,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Accepts a callback, which returns a boolean variable indicating if the user has given privacy consent yet.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. No direct replacement.
    * @param {Function} callback
    */
   @Cordova()
@@ -831,6 +1204,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * Allows you to use your own system's user ID's to send push notifications to your users.
    * To tie a user to a given user ID, you can use this method.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `login` instead.
    * @param {string} externalId
    */
   @Cordova()
@@ -838,6 +1212,8 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
 
   /**
    * Removes whatever was set as the current user's external user ID.
+   *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `logout` instead.
    */
   @Cordova()
   removeExternalUserId(): void {}
@@ -845,6 +1221,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Add a trigger. May show an In-App Message if its trigger conditions were met.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalInAppMessages.addTrigger` instead.
    * @param {string} key Key for the trigger.
    * @param {string | number | Object} value Value for the trigger. String or number recommended. Object passed in will be converted to a string.
    */
@@ -856,6 +1233,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Add a map of triggers. May show an In-App Message if its trigger conditions were met.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalInAppMessages.addTriggers` instead.
    * @param {Object.<string, string | number | Object>} triggers Allows you to set multiple trigger key/value pairs simultaneously. Pass a json object with key/value pairs like: `{"key": "value", "key2": "value2"}`.
    */
   @Cordova({
@@ -866,6 +1244,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Removes a single trigger for the given key. May show an In-App Message if its trigger conditions were met.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalInAppMessages.removeTrigger` instead.
    * @param {string} key Key for trigger to remove.
    */
   @Cordova({
@@ -876,6 +1255,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Removes a list of triggers based on a collection (array) of keys. May show an In-App Message if its trigger conditions were met.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalInAppMessages.removeTriggers` instead.
    * @param {string[]} keys Removes a collection of triggers from their keys. Pass an array of trigger keys like: `["key1", "key2", "key3"]`.
    */
   @Cordova({
@@ -886,6 +1266,7 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
   /**
    * Gets a trigger value for a provided trigger key.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. No direct replacement.
    * @param {string} key Key for trigger to get value.
    * @returns {Promise<string | number | Object>} Return value set with `addTrigger`, or `null`/`nil` (iOS) if never set or removed.
    */
@@ -898,10 +1279,953 @@ export class OneSignal extends AwesomeCordovaNativePlugin {
    * Allows you to temporarily pause all In-App Messages. You may want to do this while the user is engaged in an activity that you don't want a message to interrupt (such as watching a video).
    * An In-App Message that would display if not paused will display right after resume if its conditions to display remains satisfied.
    *
+   * @deprecated Removed in onesignal-cordova-plugin v5.0.0. Use `OneSignalInAppMessages.setPaused` instead.
    * @param {boolean} pause To pause, set `true`. To resume, set `false`.
    */
   @Cordova({
     sync: true,
   })
   pauseInAppMessages(pause: boolean): void {}
+}
+
+/**
+ * @name OneSignalUser
+ * @description
+ * Wraps the `OneSignal.User` namespace of the OneSignal SDK (onesignal-cordova-plugin v5+): aliases, email/SMS
+ * subscriptions, tags and custom events for the currently logged-in user.
+ * @usage
+ * ```typescript
+ * import { OneSignalUser } from '@awesome-cordova-plugins/onesignal/ngx';
+ *
+ * constructor(private oneSignalUser: OneSignalUser) { }
+ *
+ * ...
+ *
+ * this.oneSignalUser.addTag('key', 'value');
+ * ```
+ */
+@Plugin({
+  pluginName: 'OneSignalUser',
+  plugin: 'onesignal-cordova-plugin',
+  pluginRef: 'OneSignal.User',
+  repo: 'https://github.com/OneSignal/OneSignal-Cordova-SDK',
+  platforms: ['Android', 'iOS'],
+})
+@Injectable()
+export class OneSignalUser extends AwesomeCordovaNativePlugin {
+  /**
+   * Explicitly set a 2-character language code for the user.
+   *
+   * @param {string} language
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  setLanguage(language: string): void {
+    return;
+  }
+
+  /**
+   * Set an alias for the current user. If this alias label already exists on this user, it will be overwritten with the new alias id.
+   *
+   * @param {string} label
+   * @param {string} id
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addAlias(label: string, id: string): void {
+    return;
+  }
+
+  /**
+   * Set aliases for the current user. If any alias already exists, it will be overwritten to the new values.
+   *
+   * @param {object} aliases
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addAliases(aliases: object): void {
+    return;
+  }
+
+  /**
+   * Remove an alias from the current user.
+   *
+   * @param {string} label
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  removeAlias(label: string): void {
+    return;
+  }
+
+  /**
+   * Remove aliases from the current user.
+   *
+   * @param {string[]} labels
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  removeAliases(labels: string[]): void {
+    return;
+  }
+
+  /**
+   * Add a new email subscription to the current user.
+   *
+   * @param {string} email
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addEmail(email: string): void {
+    return;
+  }
+
+  /**
+   * Remove an email subscription from the current user. Returns false if the specified email does not exist on the user within the SDK, and no request will be made.
+   *
+   * @param {string} email
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  removeEmail(email: string): void {
+    return;
+  }
+
+  /**
+   * Add a new SMS subscription to the current user.
+   *
+   * @param {string} smsNumber
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addSms(smsNumber: string): void {
+    return;
+  }
+
+  /**
+   * Remove an SMS subscription from the current user. Returns false if the specified SMS number does not exist on the user within the SDK, and no request will be made.
+   *
+   * @param {string} smsNumber
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  removeSms(smsNumber: string): void {
+    return;
+  }
+
+  /**
+   * Add a tag for the current user. Tags are key:value string pairs used as building blocks for targeting specific users and/or personalizing messages. If the tag key already exists, it will be replaced with the value provided here.
+   *
+   * @param {string} key
+   * @param {string} value
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addTag(key: string, value: string): void {
+    return;
+  }
+
+  /**
+   * Add multiple tags for the current user. Tags are key:value string pairs used as building blocks for targeting specific users and/or personalizing messages. If the tag key already exists, it will be replaced with the value provided here.
+   *
+   * @param {object} tags
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addTags(tags: object): void {
+    return;
+  }
+
+  /**
+   * Remove the data tag with the provided key from the current user.
+   *
+   * @param {string} key
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  removeTag(key: string): void {
+    return;
+  }
+
+  /**
+   * Remove multiple tags with the provided keys from the current user.
+   *
+   * @param {string[]} keys
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  removeTags(keys: string[]): void {
+    return;
+  }
+
+  /**
+   * Returns the local tags for the current user.
+   *
+   * @returns {Promise<{ [key: string]: string }>}
+   */
+  @Cordova()
+  getTags(): Promise<{ [key: string]: string }> {
+    return;
+  }
+
+  /**
+   * Add a callback that fires when the OneSignal User state changes.
+   *
+   * @param {'change'} event
+   * @param {(event: UserChangedState) => void} listener
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addEventListener(event: 'change', listener: (event: UserChangedState) => void): void {
+    return;
+  }
+
+  /**
+   * Remove a User State observer that has been previously added.
+   *
+   * @param {'change'} event
+   * @param {(event: UserChangedState) => void} listener
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  removeEventListener(event: 'change', listener: (event: UserChangedState) => void): void {
+    return;
+  }
+
+  /**
+   * Get the nullable OneSignal Id associated with the current user.
+   *
+   * @returns {Promise<string | null>}
+   */
+  @Cordova()
+  getOnesignalId(): Promise<string | null> {
+    return;
+  }
+
+  /**
+   * Get the nullable External Id associated with the current user.
+   *
+   * @returns {Promise<string | null>}
+   */
+  @Cordova()
+  getExternalId(): Promise<string | null> {
+    return;
+  }
+
+  /**
+   * Track a custom event with the provided name and optional properties.
+   *
+   * @param {string} name The name of the custom event
+   * @param {object} [properties] Optional properties to associate with the event
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  trackEvent(name: string, properties?: object): void {
+    return;
+  }
+}
+
+/**
+ * @name OneSignalUserPushSubscription
+ * @description
+ * Wraps `OneSignal.User.pushSubscription` (onesignal-cordova-plugin v5+): the current device's push subscription
+ * (id, token, opted-in state).
+ * @usage
+ * ```typescript
+ * import { OneSignalUserPushSubscription } from '@awesome-cordova-plugins/onesignal/ngx';
+ *
+ * constructor(private oneSignalUserPushSubscription: OneSignalUserPushSubscription) { }
+ *
+ * ...
+ *
+ * this.oneSignalUserPushSubscription.optIn();
+ * ```
+ */
+@Plugin({
+  pluginName: 'OneSignalUserPushSubscription',
+  plugin: 'onesignal-cordova-plugin',
+  pluginRef: 'OneSignal.User.pushSubscription',
+  repo: 'https://github.com/OneSignal/OneSignal-Cordova-SDK',
+  platforms: ['Android', 'iOS'],
+})
+@Injectable()
+export class OneSignalUserPushSubscription extends AwesomeCordovaNativePlugin {
+  /**
+   * The readonly push subscription ID.
+   *
+   * @deprecated Use `getIdAsync` instead.
+   */
+  @CordovaProperty()
+  id: string | null | undefined;
+
+  /**
+   * The readonly push token.
+   *
+   * @deprecated Use `getTokenAsync` instead.
+   */
+  @CordovaProperty()
+  token: string | null | undefined;
+
+  /**
+   * Whether the current user is opted in to push notifications.
+   *
+   * @deprecated Use `getOptedInAsync` instead.
+   */
+  @CordovaProperty()
+  optedIn: boolean;
+
+  /**
+   * The readonly push subscription ID.
+   *
+   * @returns {Promise<string | null>}
+   */
+  @Cordova()
+  getIdAsync(): Promise<string | null> {
+    return;
+  }
+
+  /**
+   * The readonly push token.
+   *
+   * @returns {Promise<string | null>}
+   */
+  @Cordova()
+  getTokenAsync(): Promise<string | null> {
+    return;
+  }
+
+  /**
+   * Gets a boolean value indicating whether the current user is opted in to push notifications.
+   * This returns true when the app has notifications permission and optOut() is NOT called.
+   * Note: Does not take into account the existence of the subscription ID and push token.
+   * This boolean may return true but push notifications may still not be received by the user.
+   *
+   * @returns {Promise<boolean>}
+   */
+  @Cordova()
+  getOptedInAsync(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Add a callback that fires when the OneSignal push subscription state changes.
+   *
+   * @param {'change'} event
+   * @param {(event: PushSubscriptionChangedState) => void} listener
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addEventListener(event: 'change', listener: (event: PushSubscriptionChangedState) => void): void {
+    return;
+  }
+
+  /**
+   * Remove a push subscription observer that has been previously added.
+   *
+   * @param {'change'} event
+   * @param {(event: PushSubscriptionChangedState) => void} listener
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  removeEventListener(event: 'change', listener: (event: PushSubscriptionChangedState) => void): void {
+    return;
+  }
+
+  /**
+   * Call this method to receive push notifications on the device or to resume receiving of push notifications after calling optOut. If needed, this method will prompt the user for push notifications permission.
+   *
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  optIn(): void {
+    return;
+  }
+
+  /**
+   * If at any point you want the user to stop receiving push notifications on the current device (regardless of system-level permission status), you can call this method to opt out.
+   *
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  optOut(): void {
+    return;
+  }
+}
+
+/**
+ * @name OneSignalNotifications
+ * @description
+ * Wraps the `OneSignal.Notifications` namespace of the OneSignal SDK (onesignal-cordova-plugin v5+): permission
+ * requests and notification lifecycle events.
+ * @usage
+ * ```typescript
+ * import { OneSignalNotifications } from '@awesome-cordova-plugins/onesignal/ngx';
+ *
+ * constructor(private oneSignalNotifications: OneSignalNotifications) { }
+ *
+ * ...
+ *
+ * this.oneSignalNotifications.requestPermission(true);
+ *
+ * this.oneSignalNotifications.addEventListener('click', (event) => {
+ *   // do something when a notification is opened
+ * });
+ * ```
+ */
+@Plugin({
+  pluginName: 'OneSignalNotifications',
+  plugin: 'onesignal-cordova-plugin',
+  pluginRef: 'OneSignal.Notifications',
+  repo: 'https://github.com/OneSignal/OneSignal-Cordova-SDK',
+  platforms: ['Android', 'iOS'],
+})
+@Injectable()
+export class OneSignalNotifications extends AwesomeCordovaNativePlugin {
+  /**
+   * Whether this app has push notification permission.
+   *
+   * @deprecated Use `getPermissionAsync` instead.
+   * @returns {boolean}
+   */
+  @Cordova({ sync: true })
+  hasPermission(): boolean {
+    return;
+  }
+
+  /**
+   * Whether this app has push notification permission. Returns true if the user has accepted permissions,
+   * or if the app has ephemeral or provisional permission.
+   *
+   * @returns {Promise<boolean>}
+   */
+  @Cordova()
+  getPermissionAsync(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * iOS Only. Returns the enum for the native permission of the device.
+   *
+   * @returns {Promise<OSNotificationPermission>}
+   */
+  @Cordova({
+    platforms: ['iOS'],
+  })
+  permissionNative(): Promise<OSNotificationPermission> {
+    return;
+  }
+
+  /**
+   * Prompt the user for permission to receive push notifications. This will display the native system prompt to request push notification permission.
+   * Use the fallbackToSettings parameter to prompt to open the settings app if a user has already declined push permissions.
+   *
+   * @param {boolean} [fallbackToSettings]
+   * @returns {Promise<boolean>}
+   */
+  @Cordova()
+  requestPermission(fallbackToSettings?: boolean): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Whether attempting to request notification permission will show a prompt. Returns true if the device has not been prompted for push notification permission already.
+   *
+   * @returns {Promise<boolean>}
+   */
+  @Cordova()
+  canRequestPermission(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * iOS Only. Instead of having to prompt the user for permission to send them push notifications, your app can request provisional authorization.
+   *
+   * For more information: https://documentation.onesignal.com/docs/ios-customizations#provisional-push-notifications
+   *
+   * @param {(response: boolean) => void} [handler]
+   * @returns {void}
+   */
+  @Cordova({
+    sync: true,
+    platforms: ['iOS'],
+  })
+  registerForProvisionalAuthorization(handler?: (response: boolean) => void): void {
+    return;
+  }
+
+  /**
+   * Add listeners for notification events.
+   *
+   * @param {NotificationEventName} event
+   * @param {(event: NotificationEventTypeMap[K]) => void} listener
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addEventListener<K extends NotificationEventName>(
+    event: K,
+    listener: (event: NotificationEventTypeMap[K]) => void
+  ): void {
+    return;
+  }
+
+  /**
+   * Remove listeners for notification events.
+   *
+   * @param {NotificationEventName} event
+   * @param {(event: NotificationEventTypeMap[K]) => void} listener
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  removeEventListener<K extends NotificationEventName>(
+    event: K,
+    listener: (event: NotificationEventTypeMap[K]) => void
+  ): void {
+    return;
+  }
+
+  /**
+   * Removes all OneSignal notifications.
+   *
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  clearAll(): void {
+    return;
+  }
+
+  /**
+   * Android only. Cancels a single OneSignal notification based on its Android notification integer ID. Use instead of Android's NotificationManager.cancel, otherwise the notification will be restored when your app is restarted.
+   *
+   * @param {number} id notification id to cancel
+   * @returns {void}
+   */
+  @Cordova({
+    sync: true,
+    platforms: ['Android'],
+  })
+  removeNotification(id: number): void {
+    return;
+  }
+
+  /**
+   * Android only. Cancels a group of OneSignal notifications with the provided group key. Grouping notifications is a OneSignal concept, there is no NotificationManager equivalent.
+   *
+   * @param {string} id notification group id to cancel
+   * @returns {void}
+   */
+  @Cordova({
+    sync: true,
+    platforms: ['Android'],
+  })
+  removeGroupedNotifications(id: string): void {
+    return;
+  }
+}
+
+/**
+ * @name OneSignalSession
+ * @description
+ * Wraps the `OneSignal.Session` namespace of the OneSignal SDK (onesignal-cordova-plugin v5+): outcomes captured
+ * against the current session.
+ * @usage
+ * ```typescript
+ * import { OneSignalSession } from '@awesome-cordova-plugins/onesignal/ngx';
+ *
+ * constructor(private oneSignalSession: OneSignalSession) { }
+ *
+ * ...
+ *
+ * this.oneSignalSession.addOutcome('my_outcome');
+ * ```
+ */
+@Plugin({
+  pluginName: 'OneSignalSession',
+  plugin: 'onesignal-cordova-plugin',
+  pluginRef: 'OneSignal.Session',
+  repo: 'https://github.com/OneSignal/OneSignal-Cordova-SDK',
+  platforms: ['Android', 'iOS'],
+})
+@Injectable()
+export class OneSignalSession extends AwesomeCordovaNativePlugin {
+  /**
+   * Add an outcome with the provided name, captured against the current session.
+   *
+   * @param {string} name
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addOutcome(name: string): void {
+    return;
+  }
+
+  /**
+   * Add a unique outcome with the provided name, captured against the current session.
+   *
+   * @param {string} name
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addUniqueOutcome(name: string): void {
+    return;
+  }
+
+  /**
+   * Add an outcome with the provided name and value, captured against the current session.
+   *
+   * @param {string} name
+   * @param {number} value
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addOutcomeWithValue(name: string, value: number): void {
+    return;
+  }
+}
+
+/**
+ * @name OneSignalLocation
+ * @description
+ * Wraps the `OneSignal.Location` namespace of the OneSignal SDK (onesignal-cordova-plugin v5+): location sharing
+ * for geo-targeted notifications.
+ * @usage
+ * ```typescript
+ * import { OneSignalLocation } from '@awesome-cordova-plugins/onesignal/ngx';
+ *
+ * constructor(private oneSignalLocation: OneSignalLocation) { }
+ *
+ * ...
+ *
+ * this.oneSignalLocation.requestPermission();
+ * ```
+ */
+@Plugin({
+  pluginName: 'OneSignalLocation',
+  plugin: 'onesignal-cordova-plugin',
+  pluginRef: 'OneSignal.Location',
+  repo: 'https://github.com/OneSignal/OneSignal-Cordova-SDK',
+  platforms: ['Android', 'iOS'],
+})
+@Injectable()
+export class OneSignalLocation extends AwesomeCordovaNativePlugin {
+  /**
+   * Prompts the user for location permissions to allow geotagging from the OneSignal dashboard.
+   *
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  requestPermission(): void {
+    return;
+  }
+
+  /**
+   * Disable or enable location collection (defaults to enabled if your app has location permission).
+   *
+   * @param {boolean} shared
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  setShared(shared: boolean): void {
+    return;
+  }
+
+  /**
+   * Whether location is currently shared with OneSignal.
+   *
+   * @returns {Promise<boolean>}
+   */
+  @Cordova()
+  isShared(): Promise<boolean> {
+    return;
+  }
+}
+
+/**
+ * @name OneSignalInAppMessages
+ * @description
+ * Wraps the `OneSignal.InAppMessages` namespace of the OneSignal SDK (onesignal-cordova-plugin v5+): triggers and
+ * lifecycle events for In-App Messages.
+ * @usage
+ * ```typescript
+ * import { OneSignalInAppMessages } from '@awesome-cordova-plugins/onesignal/ngx';
+ *
+ * constructor(private oneSignalInAppMessages: OneSignalInAppMessages) { }
+ *
+ * ...
+ *
+ * this.oneSignalInAppMessages.addTrigger('key', 'value');
+ * ```
+ */
+@Plugin({
+  pluginName: 'OneSignalInAppMessages',
+  plugin: 'onesignal-cordova-plugin',
+  pluginRef: 'OneSignal.InAppMessages',
+  repo: 'https://github.com/OneSignal/OneSignal-Cordova-SDK',
+  platforms: ['Android', 'iOS'],
+})
+@Injectable()
+export class OneSignalInAppMessages extends AwesomeCordovaNativePlugin {
+  /**
+   * Add event listeners for In-App Message click and/or lifecycle events.
+   *
+   * @param {InAppMessageEventName} event
+   * @param {(event: InAppMessageEventTypeMap[K]) => void} listener
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addEventListener<K extends InAppMessageEventName>(
+    event: K,
+    listener: (event: InAppMessageEventTypeMap[K]) => void
+  ): void {
+    return;
+  }
+
+  /**
+   * Remove event listeners for In-App Message click and/or lifecycle events.
+   *
+   * @param {InAppMessageEventName} event
+   * @param {(event: InAppMessageEventTypeMap[K]) => void} listener
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  removeEventListener<K extends InAppMessageEventName>(
+    event: K,
+    listener: (event: InAppMessageEventTypeMap[K]) => void
+  ): void {
+    return;
+  }
+
+  /**
+   * Add a trigger for the current user. Triggers are currently explicitly used to determine whether a specific IAM should be displayed to the user.
+   *
+   * @param {string} key
+   * @param {string} value
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addTrigger(key: string, value: string): void {
+    return;
+  }
+
+  /**
+   * Add multiple triggers for the current user. Triggers are currently explicitly used to determine whether a specific IAM should be displayed to the user.
+   *
+   * @param {{ [key: string]: string }} triggers
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  addTriggers(triggers: { [key: string]: string }): void {
+    return;
+  }
+
+  /**
+   * Remove the trigger with the provided key from the current user.
+   *
+   * @param {string} key
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  removeTrigger(key: string): void {
+    return;
+  }
+
+  /**
+   * Remove multiple triggers from the current user.
+   *
+   * @param {string[]} keys
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  removeTriggers(keys: string[]): void {
+    return;
+  }
+
+  /**
+   * Clear all triggers from the current user.
+   *
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  clearTriggers(): void {
+    return;
+  }
+
+  /**
+   * Set whether in-app messaging is currently paused.
+   * When set to true no IAM will be presented to the user regardless of whether they qualify for them.
+   * When set to false any IAMs the user qualifies for will be presented to the user at the appropriate time.
+   *
+   * @param {boolean} pause
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  setPaused(pause: boolean): void {
+    return;
+  }
+
+  /**
+   * Whether in-app messaging is currently paused.
+   *
+   * @returns {Promise<boolean>}
+   */
+  @Cordova()
+  getPaused(): Promise<boolean> {
+    return;
+  }
+}
+
+/**
+ * @name OneSignalDebug
+ * @description
+ * Wraps the `OneSignal.Debug` namespace of the OneSignal SDK (onesignal-cordova-plugin v5+): SDK logging levels.
+ * @usage
+ * ```typescript
+ * import { OneSignalDebug, LogLevel } from '@awesome-cordova-plugins/onesignal/ngx';
+ *
+ * constructor(private oneSignalDebug: OneSignalDebug) { }
+ *
+ * ...
+ *
+ * this.oneSignalDebug.setLogLevel(LogLevel.Verbose);
+ * ```
+ */
+@Plugin({
+  pluginName: 'OneSignalDebug',
+  plugin: 'onesignal-cordova-plugin',
+  pluginRef: 'OneSignal.Debug',
+  repo: 'https://github.com/OneSignal/OneSignal-Cordova-SDK',
+  platforms: ['Android', 'iOS'],
+})
+@Injectable()
+export class OneSignalDebug extends AwesomeCordovaNativePlugin {
+  /**
+   * Enable logging to help debug if you run into an issue setting up OneSignal.
+   *
+   * @param {LogLevel} logLevel Sets the logging level to print to the Android LogCat log or Xcode log.
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  setLogLevel(logLevel: LogLevel): void {
+    return;
+  }
+
+  /**
+   * Enable logging to help debug if you run into an issue setting up OneSignal.
+   *
+   * @param {LogLevel} visualLogLevel Sets the logging level to show as alert dialogs.
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  setAlertLevel(visualLogLevel: LogLevel): void {
+    return;
+  }
+}
+
+/**
+ * @name OneSignalLiveActivities
+ * @description
+ * Wraps the `OneSignal.LiveActivities` namespace of the OneSignal SDK (onesignal-cordova-plugin v5+). iOS only.
+ * @usage
+ * ```typescript
+ * import { OneSignalLiveActivities } from '@awesome-cordova-plugins/onesignal/ngx';
+ *
+ * constructor(private oneSignalLiveActivities: OneSignalLiveActivities) { }
+ *
+ * ...
+ *
+ * this.oneSignalLiveActivities.setupDefault();
+ * ```
+ */
+@Plugin({
+  pluginName: 'OneSignalLiveActivities',
+  plugin: 'onesignal-cordova-plugin',
+  pluginRef: 'OneSignal.LiveActivities',
+  repo: 'https://github.com/OneSignal/OneSignal-Cordova-SDK',
+  platforms: ['iOS'],
+})
+@Injectable()
+export class OneSignalLiveActivities extends AwesomeCordovaNativePlugin {
+  /**
+   * Enter a live activity.
+   *
+   * @param {string} activityId
+   * @param {string} token
+   * @param {(data: unknown) => void} [onSuccess]
+   * @param {(data: unknown) => void} [onFailure]
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  enter(
+    activityId: string,
+    token: string,
+    onSuccess?: (data: unknown) => void,
+    onFailure?: (data: unknown) => void
+  ): void {
+    return;
+  }
+
+  /**
+   * Exit a live activity.
+   *
+   * @deprecated Currently unsupported upstream, avoid using this method.
+   * @param {string} activityId
+   * @param {(data: unknown) => void} [onSuccess]
+   * @param {(data: unknown) => void} [onFailure]
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  exit(activityId: string, onSuccess?: (data: unknown) => void, onFailure?: (data: unknown) => void): void {
+    return;
+  }
+
+  /**
+   * iOS only. Indicate this device is capable of receiving pushToStart live activities for the `activityType`. The
+   * `activityType` must be the name of the struct conforming to `ActivityAttributes` that will be used to start the
+   * live activity.
+   *
+   * @param {string} activityType The name of the specific `ActivityAttributes` structure tied to the live activity.
+   * @param {string} token The activity type's pushToStart token.
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  setPushToStartToken(activityType: string, token: string): void {
+    return;
+  }
+
+  /**
+   * iOS only. Indicate this device is no longer capable of receiving pushToStart live activities for the
+   * `activityType`. The `activityType` must be the name of the struct conforming to `ActivityAttributes` that will
+   * be used to start the live activity.
+   *
+   * @param {string} activityType The name of the specific `ActivityAttributes` structure tied to the live activity.
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  removePushToStartToken(activityType: string): void {
+    return;
+  }
+
+  /**
+   * iOS only. Enable the OneSignal SDK to setup the default `DefaultLiveActivityAttributes` structure, which
+   * conforms to `OneSignalLiveActivityAttributes`.
+   *
+   * @param {LiveActivitySetupOptions} [options] An optional structure to provide for more granular setup options.
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  setupDefault(options?: LiveActivitySetupOptions): void {
+    return;
+  }
+
+  /**
+   * iOS only. Start a new LiveActivity that is modelled by the default `DefaultLiveActivityAttributes` structure.
+   *
+   * @param {string} activityId The activity identifier the live activity on this device will be started and eligible to receive updates for.
+   * @param {object} attributes A dynamic type containing the static attributes passed into `DefaultLiveActivityAttributes`.
+   * @param {object} content A dynamic type containing the content attributes passed into `DefaultLiveActivityAttributes`.
+   * @returns {void}
+   */
+  @Cordova({ sync: true })
+  startDefault(activityId: string, attributes: object, content: object): void {
+    return;
+  }
 }


### PR DESCRIPTION
## Summary

Compared the wrapper against **onesignal-cordova-plugin v5.5.2** (latest, released 2026-07-23) using the package's official `dist/index.d.ts` typings (https://unpkg.com/onesignal-cordova-plugin@5.5.2/dist/index.d.ts) and `plugin.xml`/README from https://github.com/OneSignal/OneSignal-Cordova-SDK/tree/5.5.2.

OneSignal's Cordova SDK moved to a namespaced, user-centric API in v5.0.0. The entire legacy flat API this wrapper exposed (`startInit`, `sendTag`, `getIds`, etc.) was removed from the plugin bundle — verified by grepping the compiled v5.5.2 `dist/index.cjs` for each legacy method name (zero matches). The global also changed from `window.plugins.OneSignal` to `window.OneSignal` (`<clobbers target="OneSignal" />` in `plugin.xml`).

### Added APIs

New `OneSignal` methods (top-level, matches `OneSignalPlugin`): `initialize`, `login`, `logout`, `setConsentRequired`, `setConsentGiven`.

New injectable classes, one per upstream namespace (each with its own `pluginRef` dotted into `window.OneSignal`, e.g. `OneSignal.User`):
- `OneSignalUser` (`OneSignal.User`): `setLanguage`, `addAlias`, `addAliases`, `removeAlias`, `removeAliases`, `addEmail`, `removeEmail`, `addSms`, `removeSms`, `addTag`, `addTags`, `removeTag`, `removeTags`, `getTags`, `addEventListener`, `removeEventListener`, `getOnesignalId`, `getExternalId`, `trackEvent`
- `OneSignalUserPushSubscription` (`OneSignal.User.pushSubscription`): `id`/`token`/`optedIn` properties, `getIdAsync`, `getTokenAsync`, `getOptedInAsync`, `addEventListener`, `removeEventListener`, `optIn`, `optOut`
- `OneSignalNotifications` (`OneSignal.Notifications`): `hasPermission`, `getPermissionAsync`, `permissionNative`, `requestPermission`, `canRequestPermission`, `registerForProvisionalAuthorization`, `addEventListener`, `removeEventListener`, `clearAll`, `removeNotification`, `removeGroupedNotifications`
- `OneSignalSession` (`OneSignal.Session`): `addOutcome`, `addUniqueOutcome`, `addOutcomeWithValue`
- `OneSignalLocation` (`OneSignal.Location`): `requestPermission`, `setShared`, `isShared`
- `OneSignalInAppMessages` (`OneSignal.InAppMessages`): `addEventListener`, `removeEventListener`, `addTrigger`, `addTriggers`, `removeTrigger`, `removeTriggers`, `clearTriggers`, `setPaused`, `getPaused`
- `OneSignalDebug` (`OneSignal.Debug`): `setLogLevel`, `setAlertLevel`
- `OneSignalLiveActivities` (`OneSignal.LiveActivities`, iOS only): `enter`, `exit`, `setPushToStartToken`, `removePushToStartToken`, `setupDefault`, `startDefault`

New types/enums: `LogLevel`, `OSNotificationPermission`, `LiveActivitySetupOptions`, `UserState`, `UserChangedState`, `PushSubscriptionState`, `PushSubscriptionChangedState`, `OSInAppMessage`, `InAppMessageActionUrlType`, `InAppMessageClickResult`, `InAppMessageClickEvent`, `InAppMessageWillDisplayEvent`, `InAppMessageDidDisplayEvent`, `InAppMessageWillDismissEvent`, `InAppMessageDidDismissEvent`, `InAppMessageEventName`, `InAppMessageEventTypeMap`, `OneSignalNotification`, `NotificationClickResult`, `NotificationClickEvent`, `NotificationWillDisplayEvent`, `NotificationEventName`, `NotificationEventTypeMap`.

### Newly deprecated APIs (kept for backwards compatibility, removed upstream in onesignal-cordova-plugin v5.0.0)

`startInit`, `handleNotificationReceived`, `handleNotificationOpened`, `handleInAppMessageClicked`, `iOSSettings`, `endInit`, `promptForPushNotificationsWithUserResponse`, `getTags`, `getIds`, `sendTag`, `sendTags`, `deleteTag`, `deleteTags`, `registerForPushNotifications`, `enableVibrate`, `enableSound`, `inFocusDisplaying` (and `OSInFocusDisplayOption`), `setSubscription`, `getPermissionSubscriptionState`, `postNotification`, `cancelNotification`, `promptLocation`, `syncHashedEmail`, `setLogLevel`, `setLocationShared`, `addPermissionObserver`, `addSubscriptionObserver`, `setEmail`, `logoutEmail`, `addEmailSubscriptionObserver`, `clearOneSignalNotifications`, `setRequiresUserPrivacyConsent`, `provideUserConsent`, `userProvidedPrivacyConsent`, `setExternalUserId`, `removeExternalUserId`, `addTrigger`, `addTriggers`, `removeTriggerForKey`, `removeTriggersForKeys`, `getTriggerValueForKey`, `pauseInAppMessages` — each JSDoc'd with `@deprecated Removed in onesignal-cordova-plugin v5.0.0. Use ... instead.`

### Metadata changes

`@Plugin` `pluginRef` updated from `'plugins.OneSignal'` to `'OneSignal'` (matches current `plugin.xml` clobbers target); `platforms` updated from `['Amazon Fire OS', 'Android', 'iOS', 'Windows']` to `['Android', 'iOS']` (matches the plugin's current supported platforms).

## Documentation source

- https://unpkg.com/onesignal-cordova-plugin@5.5.2/dist/index.d.ts (official TypeScript typings)
- https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/5.5.2/plugin.xml
- https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/5.5.2/README.md

## Test plan
- [x] `npx eslint src/@awesome-cordova-plugins/plugins/onesignal/index.ts` — 0 errors (25 pre-existing `no-explicit-any` warnings in the legacy methods)
- [x] `npx tsc -p tsconfig.json --noEmit 2>&1 | grep "plugins/onesignal/"` — no output
