### PR TITLE
feat(genius-scan): add barcode scanning and sync types with 6.3.0

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/genius-scan/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/genius-scan/index.ts
@@ -40,7 +40,15 @@ export class GeniusScan extends AwesomeCordovaNativePlugin {
   }
 
   @Cordova()
-  scanWithConfiguration(configuration: ScanConfiguration): Promise<SuccessScanResult> {
+  scanWithConfiguration(configuration?: ScanConfiguration): Promise<SuccessScanResult> {
+    return;
+  }
+
+  /**
+   * Starts the barcode scanner module.
+   */
+  @Cordova()
+  scanBarcodesWithConfiguration(configuration?: BarcodeConfiguration): Promise<BarcodeResult> {
     return;
   }
 
@@ -74,14 +82,30 @@ interface ScanConfiguration {
   multiPageFormat?: 'pdf' | 'tiff' | 'none';
 
   /**
-   *  (by default, the filter is chosen automatically)
+   * The filter that will be applied by default to enhance scans, or 'none' if no
+   * enhancement should be performed by default. Possible values include 'automatic',
+   * 'automaticColor', 'automaticBlackAndWhite', 'automaticMonochrome', 'photo',
+   * 'softBlackAndWhite', 'softColor', 'strongMonochrome', 'strongBlackAndWhite',
+   * 'strongColor', 'darkBackground' and 'none' (defaults to 'automatic').
    */
-  defaultFilter?: 'none' | 'blackAndWhite' | 'monochrome' | 'color' | 'photo';
+  defaultFilter?: string;
+
+  /**
+   * an array of filters that the user can select when they tap on the edit filter button.
+   * Defaults to ['none', 'automatic', 'automaticMonochrome', 'automaticBlackAndWhite', 'automaticColor', 'photo'].
+   */
+  availableFilters?: string[];
 
   /**
    * defaults to fit
    */
   pdfPageSize?: 'fit' | 'a4' | 'letter';
+
+  /**
+   * Optional password used to protect generated PDF documents. Empty passwords are
+   * treated as no password. Only applies when multiPageFormat is 'pdf'.
+   */
+  pdfPassword?: string;
 
   /**
    * max dimension in pixels when images are scaled before PDF generation,
@@ -104,10 +128,40 @@ interface ScanConfiguration {
   jpegQuality?: number;
 
   /**
+   * Whether to skip showing the post-processing screen. Only recommended when
+   * scanning structured data; generally the user should visually confirm each scan.
+   */
+  skipPostProcessingScreen?: boolean;
+
+  /**
    * an array with the desired actions to display during the post processing screen
    * (defaults to all actions).
    */
   postProcessingActions?: ('rotate' | 'editFilter' | 'correctDistortion')[];
+
+  /**
+   * whether a curvature correction should be applied by default (defaults to 'disabled').
+   */
+  defaultCurvatureCorrection?: 'enabled' | 'disabled';
+
+  /**
+   * automatically show crop validation after capture. 'never', 'always', or an object
+   * with a confidence threshold below which validation should be shown.
+   */
+  showCropValidation?:
+    'never' | 'always' | { whenConfidenceBelowOrEqual: 'lowest' | 'low' | 'medium' | 'high' | 'highest' };
+
+  /**
+   * 'automatic' to rotate scan automatically after capture or 'original' to keep the
+   * original scan orientation (defaults to 'automatic').
+   */
+  defaultScanOrientation?: 'automatic' | 'original';
+
+  /**
+   * whether the button allowing the user to pick an image on the Camera screen
+   * should be hidden (defaults to false).
+   */
+  photoLibraryButtonHidden?: boolean;
 
   /**
    * (default to false)
@@ -160,13 +214,68 @@ interface ScanConfiguration {
      */
     outputFormats?: ('rawText' | 'hOCR' | 'textLayerInPDF')[];
   };
+
+  /**
+   * an array of the structured data you want to extract. E.g.: ['receipt', 'businessCard'].
+   * Possible values are 'receipt', 'barcode', 'bankDetails' (iOS only), 'businessCard' (iOS only).
+   */
+  structuredData?: string[];
+
+  /**
+   * an array of the barcode types to extract, e.g. ['qr', 'code39']. Possible values are
+   * 'aztec', 'code39', 'code93', 'code128', 'dataMatrix', 'ean8', 'ean13', 'itf', 'pdf417',
+   * 'qr', 'upca' (Android only), 'upce', 'codabar' (iOS 15+ only), 'gs1DataBar' (iOS 15+ only),
+   * 'microPDF417' (iOS 15+ only), 'microQR' (iOS 15+ only), 'msiPlessey' (iOS 17+ only).
+   */
+  structuredDataBarcodeTypes?: string[];
+
+  /**
+   * the required readability level below which a warning will be displayed to the user
+   * (defaults to 'lowest', which means the warning will never be displayed).
+   */
+  requiredReadabilityLevel?: 'lowest' | 'low' | 'medium' | 'high' | 'highest';
+
+  /**
+   * whether the final review screen should be displayed before submission (default to false).
+   */
+  showFinalReview?: boolean;
+}
+
+interface BarcodeConfiguration {
+  /**
+   * whether the barcode scanner should keep scanning and accumulating results after
+   * detecting a first barcode.
+   */
+  isBatchModeEnabled?: boolean;
+
+  /**
+   * an array of the barcode types to detect. Defaults to all supported types.
+   */
+  supportedCodeTypes?: string[];
+}
+
+interface BarcodeResult {
+  /**
+   * an array of the detected barcodes.
+   */
+  barcodes: {
+    /**
+     * the decoded value of the barcode.
+     */
+    value: string;
+
+    /**
+     * the type of the barcode, e.g. 'qr', 'code128'.
+     */
+    type: string;
+  }[];
 }
 
 interface SuccessScanResult {
   /**
    * a document containing all the scanned pages (example: "file://.pdf")
    */
-  multiPageDocumentUrl: string;
+  multiPageDocumentUrl?: string;
 
   /**
    * an array of scan objects.
@@ -183,9 +292,9 @@ interface SuccessScanResult {
     enhancedUrl: string;
 
     /**
-     * the result of text recognition for this scan
+     * the result of text recognition for this scan, present when ocrConfiguration was set.
      */
-    ocrResult: {
+    ocrResult?: {
       /**
        * the raw text that was recognized
        */
@@ -194,8 +303,14 @@ interface SuccessScanResult {
       /**
        * the recognized text in hOCR format (with position, style…)
        */
-      hocrTextLayout: string;
+      hocrTextLayout?: string;
     };
+
+    /**
+     * the result of the structured data extraction, present when structuredData was set.
+     * A subdictionary is present for each type of structured data detected.
+     */
+    structuredData?: any;
   }[];
 }
 
@@ -209,7 +324,7 @@ interface GenerateDocumentPages {
     /**
      * the text layout in hOCR format
      */
-    hocrTextLayout: string;
+    hocrTextLayout?: string;
   }[];
 }
 


### PR DESCRIPTION
## Summary

Upstream `@thegrizzlylabs/cordova-plugin-genius-scan` compared: current wrapper (last touched 2024-07-11) against **6.3.0** (2026-07-09), using the published `types/index.d.ts` and `README.md`:
- https://unpkg.com/@thegrizzlylabs/cordova-plugin-genius-scan@6.3.0/types/index.d.ts
- https://unpkg.com/@thegrizzlylabs/cordova-plugin-genius-scan@6.3.0/README.md

### Added APIs
- `scanBarcodesWithConfiguration(configuration?: BarcodeConfiguration): Promise<BarcodeResult>` — new upstream method for the barcode scanner module, with new `BarcodeConfiguration` (`isBatchModeEnabled`, `supportedCodeTypes`) and `BarcodeResult` (`barcodes: { value, type }[]`) interfaces.
- `ScanConfiguration` new optional fields: `availableFilters`, `skipPostProcessingScreen`, `defaultCurvatureCorrection`, `showCropValidation`, `defaultScanOrientation`, `photoLibraryButtonHidden`, `structuredData`, `structuredDataBarcodeTypes`, `requiredReadabilityLevel`, `pdfPassword`, `showFinalReview`.
- `SuccessScanResult.scans[].structuredData?: any` — result of structured data extraction, present when `structuredData` was requested.
- `scanWithConfiguration`'s `configuration` parameter is now optional (matches upstream `configuration?: ScanConfiguration`); widening a required param to optional, non-breaking.

### Newly deprecated APIs
None — every existing exported method/interface/property from the previous wrapper is still present upstream in 6.3.0.

### Potentially breaking
- `ScanConfiguration.defaultFilter` widened from `'none' | 'blackAndWhite' | 'monochrome' | 'color' | 'photo'` to `string`. Upstream's `.d.ts` now types it as `string`, and the current valid values per the README (`automatic`, `automaticColor`, `automaticBlackAndWhite`, `automaticMonochrome`, `photo`, `softBlackAndWhite`, `softColor`, `strongMonochrome`, `strongBlackAndWhite`, `strongColor`, `darkBackground`, `none`) no longer match the old literal union at all (e.g. `blackAndWhite`/`monochrome`/`color` don't exist anymore). Keeping the stale union would reject every currently-valid value, so it was widened to `string` instead. This is a compile-time widening (previously-valid literals still compile), not a narrowing.
- `SuccessScanResult.multiPageDocumentUrl` changed from required to optional (`string` → `string?`), matching upstream `ScanResult.multiPageDocumentUrl?: string`.
- `SuccessScanResult.scans[].ocrResult` changed from required to optional, and its `hocrTextLayout` field changed from required to optional, matching upstream `Scan.ocrResult?: { text: string; hocrTextLayout?: string }`.
- `GenerateDocumentPages.pages[].hocrTextLayout` changed from required to optional, matching upstream `PDFPage.hocrTextLayout?: string`.

All of the above are optional-loosening changes (no property removed, no narrower type introduced), evidenced directly by the upstream `.d.ts`.

## Test plan
- [x] `npx eslint src/@awesome-cordova-plugins/plugins/genius-scan/index.ts` — 0 errors (3 pre-existing-style `no-explicit-any` warnings, consistent with existing `Promise<any>` usage in this file)
- [x] `npx tsc -p tsconfig.json --noEmit 2>&1 | grep "plugins/genius-scan/"` — only the pre-existing, repo-wide `Cannot find module '@awesome-cordova-plugins/core'` error, confirmed present identically on the unmodified file via `git stash` (this is an environment/module-resolution artifact of this worktree affecting all 258 plugin wrappers, not caused by this change)
