### PR TITLE
feat(barkoder): sync wrapper with barkoder-cordova 1.6.8 API

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/barkoder/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/barkoder/index.ts
@@ -82,6 +82,40 @@ export class Barkoder extends AwesomeCordovaNativePlugin {
     return;
   }
 
+  /**
+   * Freezes the current AR scanning session by capturing a still image from the camera feed.
+   * Use only when AR mode is enabled to temporarily freeze the view while keeping overlays visible.
+   */
+  @Cordova()
+  freezeScanning(): Promise<any> {
+    return;
+  }
+
+  /**
+   * Unfreezes the AR scanning session by removing the still image and reactivating the camera and overlays.
+   * Use only when AR mode is enabled to restore the live AR view and continue scanning.
+   */
+  @Cordova()
+  unfreezeScanning(): Promise<any> {
+    return;
+  }
+
+  /**
+   * Captures the latest camera frame
+   */
+  @Cordova()
+  captureImage(): Promise<any> {
+    return;
+  }
+
+  /**
+   * Scan barcodes from base64 string image
+   */
+  @Cordova()
+  scanImage(base64: string): Promise<any> {
+    return;
+  }
+
   @Cordova()
   setLocationLineColor(hexColor: string): Promise<any> {
     return;
@@ -227,6 +261,9 @@ export class Barkoder extends AwesomeCordovaNativePlugin {
     return;
   }
 
+  /**
+   * @deprecated Removed upstream in barkoder-cordova 1.6.4. Use `setThresholdBetweenDuplicatesScans` instead.
+   */
   @Cordova()
   setDuplicatesDelayMs(delayMs: number): Promise<any> {
     return;
@@ -252,13 +289,427 @@ export class Barkoder extends AwesomeCordovaNativePlugin {
     return;
   }
 
-  @Cordova()
+  // Native bridge exposes this as `setDatamatrixDpmModeEnabled` (lowercase "m"); methodName keeps this call working.
+  @Cordova({ methodName: 'setDatamatrixDpmModeEnabled' })
   setDataMatrixDpmModeEnabled(enabled: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets whether the Direct Part Marking (DPM) mode for QR barcodes is enabled
+   */
+  @Cordova()
+  setQrDpmModeEnabled(enabled: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets whether the Direct Part Marking (DPM) mode for QR Micro barcodes is enabled
+   */
+  @Cordova()
+  setQrMicroDpmModeEnabled(enabled: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets whether the QR multi-part merge is enabled
+   */
+  @Cordova()
+  setQrMultiPartMergeEnabled(enabled: boolean): Promise<any> {
     return;
   }
 
   @Cordova()
   configureBarkoder(barkoderConfig: BarkoderConfig): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets whether Master checksum should be required when scanning ID Documents
+   */
+  @Cordova()
+  setIdDocumentMasterChecksumEnabled(enabled: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets whether UPC-E barcodes should be expanded to UPC-A format
+   */
+  @Cordova()
+  setUPCEexpandToUPCA(enabled: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets whether UPC-E1 barcodes should be expanded to UPC-A format
+   */
+  @Cordova()
+  setUPCE1expandToUPCA(enabled: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the color of the scanning indicator line on the camera feed
+   */
+  @Cordova()
+  setScanningIndicatorColor(hexColor: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the width of the scanning indicator line on the camera feed
+   */
+  @Cordova()
+  setScanningIndicatorWidth(lineWidth: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the animation of the scanning indicator on the camera feed
+   */
+  @Cordova()
+  setScanningIndicatorAnimation(animation: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the scanning indicator to always be shown on the camera feed
+   */
+  @Cordova()
+  setScanningIndicatorAlwaysVisible(value: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets a custom option
+   */
+  @Cordova()
+  setCustomOption(option: string, value: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets a custom option globally (must be called before creating the Barkoder config)
+   */
+  @Cordova()
+  setCustomOptionGlobal(option: number, value: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the camera's exposure dynamically based on the provided intensity, cycling through predefined compensation values
+   */
+  @Cordova()
+  setDynamicExposure(intensity: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the camera to use the center of the viewfinder for focus and exposure
+   */
+  @Cordova()
+  setCentricFocusAndExposure(value: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets whether Composite Mode should be enabled when scanning
+   */
+  @Cordova()
+  setEnableComposite(value: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Enables or disables video stabilization for smoother video capture
+   */
+  @Cordova()
+  setVideoStabilization(value: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the camera to be used for scanning (back/front)
+   */
+  @Cordova()
+  setCamera(value: BarkoderCameraPosition): Promise<any> {
+    return;
+  }
+
+  /**
+   * Enables or disables showing duplicate barcode locations on the preview overlay
+   */
+  @Cordova()
+  setShowDuplicatesLocations(value: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the AR mode used for barcode scanning visualization
+   */
+  @Cordova()
+  setARMode(value: BarkoderARMode): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the delay after which a detected AR result is considered expired
+   */
+  @Cordova()
+  setARResultDisappearanceDelayMs(value: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the speed of overlay transition for AR barcode locations
+   */
+  @Cordova()
+  setARLocationTransitionSpeed(value: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the refresh mode for the AR overlay
+   */
+  @Cordova()
+  setAROverlayRefresh(value: BarkoderAROverlayRefresh): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the overlay color for selected barcodes in AR mode
+   */
+  @Cordova()
+  setARSelectedLocationColor(value: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the overlay color for non-selected barcodes in AR mode
+   */
+  @Cordova()
+  setARNonSelectedLocationColor(value: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets line width for selected barcode overlay in AR mode
+   */
+  @Cordova()
+  setARSelectedLocationLineWidth(value: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets line width for non-selected barcode overlay in AR mode
+   */
+  @Cordova()
+  setARNonSelectedLocationLineWidth(value: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets AR location style (tight, bounding box, none)
+   */
+  @Cordova()
+  setARLocationType(value: BarkoderARLocationType): Promise<any> {
+    return;
+  }
+
+  /**
+   * Enables or disables double-tap to freeze scanning in AR mode
+   */
+  @Cordova()
+  setARDoubleTapToFreezeEnabled(enabled: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Enables or disables the capturing and processing of image data when a barcode is selected for AR mode
+   */
+  @Cordova()
+  setARImageResultEnabled(enabled: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Enables or disables the barcode thumbnail on result for AR mode
+   */
+  @Cordova()
+  setARBarcodeThumbnailOnResultEnabled(enabled: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the maximum number of results allowed in a single AR scanning session
+   */
+  @Cordova()
+  setARResultLimit(value: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets whether scanning continues when the result limit is reached (only in `.interactiveDisabled` mode)
+   */
+  @Cordova()
+  setARContinueScanningOnLimit(value: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets whether results are emitted only at AR session end (or when the limit is reached)
+   */
+  @Cordova()
+  setAREmitResultsAtSessionEndOnly(value: boolean): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets height of header label above barcode in AR mode
+   */
+  @Cordova()
+  setARHeaderHeight(value: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets header visibility condition (always, on selected, never)
+   */
+  @Cordova()
+  setARHeaderShowMode(value: BarkoderARHeaderShowMode): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets max text height for AR header
+   */
+  @Cordova()
+  setARHeaderMaxTextHeight(value: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets min text height for AR header
+   */
+  @Cordova()
+  setARHeaderMinTextHeight(value: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets text color for selected barcode header
+   */
+  @Cordova()
+  setARHeaderTextColorSelected(value: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets text color for non-selected barcode header
+   */
+  @Cordova()
+  setARHeaderTextColorNonSelected(value: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the horizontal margin applied to the header text in AR mode, creating equal padding on both sides
+   */
+  @Cordova()
+  setARHeaderHorizontalTextMargin(value: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets the vertical margin applied to the header text in AR mode, creating equal padding on both sides
+   */
+  @Cordova()
+  setARHeaderVerticalTextMargin(value: number): Promise<any> {
+    return;
+  }
+
+  /**
+   * Sets AR header text format using placeholders (e.g. [barcode_text])
+   */
+  @Cordova()
+  setARHeaderTextFormat(value: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Configures the close button
+   */
+  @Cordova()
+  configureCloseButton(
+    visible: boolean,
+    positionX: number,
+    positionY: number,
+    iconSize: number,
+    tintColor: string,
+    backgroundColor: string,
+    cornerRadius: number,
+    padding: number,
+    useCustomIcon: boolean,
+    customIcon: string
+  ): Promise<any> {
+    return;
+  }
+
+  /**
+   * Configures the flash (torch) button. Auto-hides if torch is unavailable
+   */
+  @Cordova()
+  configureFlashButton(
+    visible: boolean,
+    positionX: number,
+    positionY: number,
+    iconSize: number,
+    tintColor: string,
+    backgroundColor: string,
+    cornerRadius: number,
+    padding: number,
+    useCustomIcon: boolean,
+    customIconFlashOn: string,
+    customIconFlashOff: string
+  ): Promise<any> {
+    return;
+  }
+
+  /**
+   * Configures the zoom button
+   */
+  @Cordova()
+  configureZoomButton(
+    visible: boolean,
+    positionX: number,
+    positionY: number,
+    iconSize: number,
+    tintColor: string,
+    backgroundColor: string,
+    cornerRadius: number,
+    padding: number,
+    useCustomIcon: boolean,
+    customIconZoomedIn: string,
+    customIconZoomedOut: string,
+    zoomedInFactor: number,
+    zoomedOutFactor: number
+  ): Promise<any> {
+    return;
+  }
+
+  /**
+   * Selects all barcodes that are currently visible in AR mode
+   */
+  @Cordova()
+  selectVisibleBarcodes(): Promise<any> {
+    return;
+  }
+
+  /**
+   * Power saving mode level. Higher values reduce CPU/battery usage by limiting frame processing. 0 = disabled (no constraints)
+   */
+  @Cordova()
+  setPowerSavingMode(powerSavingMode: number): Promise<any> {
     return;
   }
 
@@ -313,6 +764,14 @@ export class Barkoder extends AwesomeCordovaNativePlugin {
     return;
   }
 
+  /**
+   * Retrieves the version of the Barkoder library
+   */
+  @Cordova()
+  getLibVersion(): Promise<string> {
+    return;
+  }
+
   @Cordova()
   getLocationLineColorHex(): Promise<string> {
     return;
@@ -330,6 +789,14 @@ export class Barkoder extends AwesomeCordovaNativePlugin {
 
   @Cordova()
   getMaxZoomFactor(): Promise<number> {
+    return;
+  }
+
+  /**
+   * Retrieves the current zoom factor for the device's camera
+   */
+  @Cordova()
+  getCurrentZoomFactor(): Promise<number> {
     return;
   }
 
@@ -393,6 +860,9 @@ export class Barkoder extends AwesomeCordovaNativePlugin {
     return;
   }
 
+  /**
+   * @deprecated Removed upstream in barkoder-cordova 1.6.4. Use `getThresholdBetweenDuplicatesScans` instead.
+   */
   @Cordova()
   getDuplicatesDelayMs(): Promise<any> {
     return;
@@ -442,12 +912,293 @@ export class Barkoder extends AwesomeCordovaNativePlugin {
   getBarkoderResolution(): Promise<any> {
     return;
   }
+
+  /**
+   * Retrieves whether Direct Part Marking (DPM) mode for Datamatrix barcodes is enabled
+   */
+  @Cordova()
+  isDatamatrixDpmModeEnabled(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Retrieves whether Direct Part Marking (DPM) mode for QR barcodes is enabled
+   */
+  @Cordova()
+  isQrDpmModeEnabled(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Retrieves whether Direct Part Marking (DPM) mode for QR Micro barcodes is enabled
+   */
+  @Cordova()
+  isQrMicroDpmModeEnabled(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Retrieves whether QR multi-part merge is enabled
+   */
+  @Cordova()
+  isQrMultiPartMergeEnabled(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Retrieves whether Master checksum is enabled when scanning ID Documents
+   */
+  @Cordova()
+  isIdDocumentMasterChecksumEnabled(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Retrieves the hexadecimal color code representing the line color of the scanning indicator on the camera preview
+   */
+  @Cordova()
+  getScanningIndicatorColorHex(): Promise<string> {
+    return;
+  }
+
+  /**
+   * Retrieves the current width setting for the scanning indicator on the camera preview
+   */
+  @Cordova()
+  getScanningIndicatorWidth(): Promise<number> {
+    return;
+  }
+
+  /**
+   * Retrieves the current animation setting for the scanning indicator on the camera preview
+   */
+  @Cordova()
+  getScanningIndicatorAnimation(): Promise<any> {
+    return;
+  }
+
+  /**
+   * Retrieves whether the scanning indicator is always visible on the camera preview
+   */
+  @Cordova()
+  isScanningIndicatorAlwaysVisible(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Retrieves whether showing duplicate barcode locations in the AR view is enabled
+   */
+  @Cordova()
+  getShowDuplicatesLocations(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Retrieves the current AR mode used for barcode scanning
+   */
+  @Cordova()
+  getARMode(): Promise<BarkoderARMode> {
+    return;
+  }
+
+  /**
+   * Retrieves the delay after which AR results disappear once detected
+   */
+  @Cordova()
+  getARResultDisappearanceDelayMs(): Promise<number> {
+    return;
+  }
+
+  /**
+   * Retrieves the transition speed for AR barcode location overlays
+   */
+  @Cordova()
+  getARLocationTransitionSpeed(): Promise<number> {
+    return;
+  }
+
+  /**
+   * Retrieves the AR overlay refresh mode
+   */
+  @Cordova()
+  getAROverlayRefresh(): Promise<BarkoderAROverlayRefresh> {
+    return;
+  }
+
+  /**
+   * Retrieves the color used for selected barcode overlays in AR mode
+   */
+  @Cordova()
+  getARSelectedLocationColor(): Promise<string> {
+    return;
+  }
+
+  /**
+   * Retrieves the color used for non-selected barcode overlays in AR mode
+   */
+  @Cordova()
+  getARNonSelectedLocationColor(): Promise<string> {
+    return;
+  }
+
+  /**
+   * Retrieves the line width for selected barcode overlays in AR mode
+   */
+  @Cordova()
+  getARSelectedLocationLineWidth(): Promise<number> {
+    return;
+  }
+
+  /**
+   * Retrieves the line width for non-selected barcode overlays in AR mode
+   */
+  @Cordova()
+  getARNonSelectedLocationLineWidth(): Promise<number> {
+    return;
+  }
+
+  /**
+   * Retrieves the style of AR location overlays (tight, bounding box, none)
+   */
+  @Cordova()
+  getARLocationType(): Promise<BarkoderARLocationType> {
+    return;
+  }
+
+  /**
+   * Checks whether double-tap to freeze is enabled in AR mode
+   */
+  @Cordova()
+  isARDoubleTapToFreezeEnabled(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Retrieves whether image result is enabled for AR mode
+   */
+  @Cordova()
+  isARImageResultEnabled(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Retrieves whether barcode thumbnail on result is enabled for AR mode
+   */
+  @Cordova()
+  isARBarcodeThumbnailOnResultEnabled(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Retrieves the maximum number of results allowed in a single AR scanning session
+   */
+  @Cordova()
+  getARResultLimit(): Promise<number> {
+    return;
+  }
+
+  /**
+   * Retrieves whether scanning continues when the result limit is reached (only in `.interactiveDisabled` mode)
+   */
+  @Cordova()
+  getARContinueScanningOnLimit(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Retrieves whether results are emitted only at AR session end (or when the limit is reached)
+   */
+  @Cordova()
+  getAREmitResultsAtSessionEndOnly(): Promise<boolean> {
+    return;
+  }
+
+  /**
+   * Retrieves the header height above barcode in AR mode
+   */
+  @Cordova()
+  getARHeaderHeight(): Promise<number> {
+    return;
+  }
+
+  /**
+   * Retrieves the header display mode (always, on selected, never)
+   */
+  @Cordova()
+  getARHeaderShowMode(): Promise<BarkoderARHeaderShowMode> {
+    return;
+  }
+
+  /**
+   * Retrieves the maximum text height for AR headers
+   */
+  @Cordova()
+  getARHeaderMaxTextHeight(): Promise<number> {
+    return;
+  }
+
+  /**
+   * Retrieves the minimum text height for AR headers
+   */
+  @Cordova()
+  getARHeaderMinTextHeight(): Promise<number> {
+    return;
+  }
+
+  /**
+   * Retrieves the header text color for selected barcodes
+   */
+  @Cordova()
+  getARHeaderTextColorSelected(): Promise<string> {
+    return;
+  }
+
+  /**
+   * Retrieves the header text color for non-selected barcodes
+   */
+  @Cordova()
+  getARHeaderTextColorNonSelected(): Promise<string> {
+    return;
+  }
+
+  /**
+   * Retrieves the horizontal margin for AR header text
+   */
+  @Cordova()
+  getARHeaderHorizontalTextMargin(): Promise<number> {
+    return;
+  }
+
+  /**
+   * Retrieves the vertical margin for AR header text
+   */
+  @Cordova()
+  getARHeaderVerticalTextMargin(): Promise<number> {
+    return;
+  }
+
+  /**
+   * Retrieves the format string used for AR header text
+   */
+  @Cordova()
+  getARHeaderTextFormat(): Promise<string> {
+    return;
+  }
+
+  /**
+   * Retrieves the power saving mode level
+   */
+  @Cordova()
+  getPowerSavingMode(): Promise<number> {
+    return;
+  }
 }
 
 export enum DecodingSpeed {
   fast,
   normal,
   slow,
+  rigorous,
 }
 
 export enum FormattingType {
@@ -455,6 +1206,7 @@ export enum FormattingType {
   automatic,
   gs1,
   aamva,
+  sadl,
 }
 
 export enum MsiChecksumType {
@@ -478,10 +1230,19 @@ export enum Code11ChecksumType {
   double,
 }
 
+/**
+ * `normal`/`high` are the original member names from this wrapper; `HD`/`FHD`/`UHD` are the
+ * current upstream names (same underlying values) as of barkoder-cordova 1.6.8, plus the new `UHD` level.
+ */
+/* eslint-disable @typescript-eslint/no-duplicate-enum-values -- HD/FHD intentionally alias normal/high for backwards compatibility */
 export enum BarkoderResolution {
-  normal,
-  high,
+  normal = 0,
+  high = 1,
+  HD = 0,
+  FHD = 1,
+  UHD = 2,
 }
+/* eslint-enable @typescript-eslint/no-duplicate-enum-values */
 
 export enum BarcodeType {
   aztec,
@@ -512,6 +1273,53 @@ export enum BarcodeType {
   code32,
   telepen,
   dotcode,
+  idDocument,
+  databar14,
+  databarLimited,
+  databarExpanded,
+  postalIMB,
+  postnet,
+  planet,
+  australianPost,
+  royalMail,
+  kix,
+  japanesePost,
+  maxiCode,
+  ocrText,
+}
+
+export enum BarkoderCameraPosition {
+  BACK,
+  FRONT,
+}
+
+export enum BarkoderARMode {
+  off,
+  interactiveDisabled,
+  interactiveEnabled,
+  nonInteractive,
+}
+
+export enum BarkoderAROverlayRefresh {
+  smooth,
+  normal,
+}
+
+export enum BarkoderARLocationType {
+  none,
+  tight,
+  boundingBox,
+}
+
+export enum BarkoderARHeaderShowMode {
+  never,
+  always,
+  onSelected,
+}
+
+export enum IdDocumentMasterChecksumType {
+  disabled,
+  enabled,
 }
 
 export class BarkoderConfig {
@@ -520,6 +1328,10 @@ export class BarkoderConfig {
   roiLineColor?: string;
   roiLineWidth?: number;
   roiOverlayBackgroundColor?: string;
+  scanningIndicatorColor?: string;
+  scanningIndicatorWidth?: number;
+  scanningIndicatorAnimation?: number;
+  scanningIndicatorAlwaysVisible?: boolean;
   closeSessionOnResultEnabled?: boolean;
   imageResultEnabled?: boolean;
   locationInImageResultEnabled?: boolean;
@@ -527,9 +1339,11 @@ export class BarkoderConfig {
   pinchToZoomEnabled?: boolean;
   regionOfInterestVisible?: boolean;
   barkoderResolution?: BarkoderResolution;
+  powerSavingMode?: number;
   beepOnSuccessEnabled?: boolean;
   vibrateOnSuccessEnabled?: boolean;
   decoder?: DekoderConfig;
+  arConfig?: BarkoderARConfig;
 
   constructor(config: Partial<BarkoderConfig>) {
     Object.assign(this, config);
@@ -539,8 +1353,8 @@ export class BarkoderConfig {
 export class DekoderConfig {
   aztec?: BarcodeConfig;
   aztecCompact?: BarcodeConfig;
-  qr?: BarcodeConfig;
-  qrMicro?: BarcodeConfig;
+  qr?: QRBarcodeConfig;
+  qrMicro?: DatamatrixBarcodeConfig;
   code128?: BarcodeConfigWithLength;
   code93?: BarcodeConfigWithLength;
   code39?: Code39BarcodeConfig;
@@ -565,9 +1379,53 @@ export class DekoderConfig {
   code32?: BarcodeConfig;
   telepen?: BarcodeConfig;
   dotcode?: BarcodeConfig;
+  idDocument?: IdDocumentBarcodeConfig;
+  databar14?: BarcodeConfig;
+  databarLimited?: BarcodeConfig;
+  databarExpanded?: BarcodeConfig;
+  postalIMB?: BarcodeConfig;
+  postnet?: BarcodeConfig;
+  planet?: BarcodeConfig;
+  australianPost?: BarcodeConfig;
+  royalMail?: BarcodeConfig;
+  kix?: BarcodeConfig;
+  japanesePost?: BarcodeConfig;
+  maxiCode?: BarcodeConfig;
+  ocrText?: BarcodeConfig;
   general?: GeneralSettings;
 
   constructor(config: Partial<DekoderConfig>) {
+    Object.assign(this, config);
+  }
+}
+
+export class BarkoderARConfig {
+  arMode?: BarkoderARMode;
+  resultDisappearanceDelayMs?: number;
+  locationTransitionSpeed?: number;
+  overlayRefresh?: BarkoderAROverlayRefresh;
+  selectedLocationColor?: string;
+  nonSelectedLocationColor?: string;
+  selectedLocationLineWidth?: number;
+  nonSelectedLocationLineWidth?: number;
+  locationType?: BarkoderARLocationType;
+  doubleTapToFreezeEnabled?: boolean;
+  imageResultEnabled?: boolean;
+  barcodeThumbnailOnResult?: boolean;
+  resultLimit?: number;
+  continueScanningOnLimit?: boolean;
+  emitResultsAtSessionEndOnly?: boolean;
+  headerHeight?: number;
+  headerShowMode?: BarkoderARHeaderShowMode;
+  headerMaxTextHeight?: number;
+  headerMinTextHeight?: number;
+  headerTextColorSelected?: string;
+  headerTextColorNonSelected?: string;
+  headerHorizontalTextMargin?: number;
+  headerVerticalTextMargin?: number;
+  headerTextFormat?: string;
+
+  constructor(config: Partial<BarkoderARConfig>) {
     Object.assign(this, config);
   }
 }
@@ -659,6 +1517,32 @@ export class DatamatrixBarcodeConfig {
   }
 }
 
+export class QRBarcodeConfig {
+  enabled?: boolean;
+  dpmMode?: number;
+  multiPartMerge?: boolean;
+  minLength?: number;
+  maxLength?: number;
+
+  constructor(config: Partial<QRBarcodeConfig>) {
+    Object.assign(this, config);
+  }
+
+  setLengthRange(minLength: number, maxLength: number) {
+    this.minLength = minLength;
+    this.maxLength = maxLength;
+  }
+}
+
+export class IdDocumentBarcodeConfig {
+  enabled?: boolean;
+  masterChecksum?: IdDocumentMasterChecksumType;
+
+  constructor(config: Partial<IdDocumentBarcodeConfig>) {
+    Object.assign(this, config);
+  }
+}
+
 export class GeneralSettings {
   threadsLimit?: number;
   decodingSpeed?: DecodingSpeed;
@@ -669,6 +1553,9 @@ export class GeneralSettings {
   formattingType?: FormattingType;
   encodingCharacterSet?: string;
   maximumResultsCount?: number;
+  /**
+   * @deprecated Removed upstream in barkoder-cordova 1.6.4. Use the `setThresholdBetweenDuplicatesScans`/`getThresholdBetweenDuplicatesScans` methods instead.
+   */
   duplicatesDelayMs?: number;
   multicodeCachingDuration?: number;
   multicodeCachingEnabled?: boolean;
@@ -684,5 +1571,64 @@ export class GeneralSettings {
     this.roiY = y;
     this.roiWidth = width;
     this.roiHeight = height;
+  }
+}
+
+export class BarkoderResult {
+  decoderResults: DecoderResult[];
+  resultThumbnailsAsBase64?: string[] | null;
+  resultImageAsBase64?: string | null;
+
+  constructor(resultMap: Record<string, any>) {
+    if (Array.isArray(resultMap['decoderResults'])) {
+      this.decoderResults = resultMap['decoderResults'].map((result: any) => new DecoderResult(result));
+    } else {
+      this.decoderResults = [];
+    }
+
+    this.resultThumbnailsAsBase64 = Array.isArray(resultMap['resultThumbnailsAsBase64'])
+      ? resultMap['resultThumbnailsAsBase64']
+          .map((thumbnail) => this.convertToBase64(thumbnail))
+          .filter((thumbnail): thumbnail is string => thumbnail !== null)
+      : null;
+
+    this.resultImageAsBase64 = this.convertToBase64(resultMap['resultImageAsBase64']);
+  }
+
+  private convertToBase64(data: string | null | undefined): string | null {
+    return data ? `data:image/jpeg;base64,${data}` : null;
+  }
+}
+
+export class DecoderResult {
+  barcodeType: number;
+  barcodeTypeName: string;
+  binaryDataAsBase64: string;
+  textualData: string;
+  characterSet?: string | null;
+  extra?: Record<string, any> | null;
+  mrzImagesAsBase64?: { name: string; base64: string }[];
+  sadlImageAsBase64?: string | null;
+  locationPoints?: { x: number; y: number }[];
+
+  constructor(resultMap: Record<string, any>) {
+    this.barcodeType = resultMap['barcodeType'];
+    this.barcodeTypeName = resultMap['barcodeTypeName'];
+    this.binaryDataAsBase64 = resultMap['binaryDataAsBase64'];
+    this.textualData = resultMap['textualData'];
+    this.characterSet = resultMap['characterSet'] || null;
+    this.extra = 'extra' in resultMap ? JSON.parse(resultMap['extra']) : null;
+    this.mrzImagesAsBase64 = Array.isArray(resultMap['mrzImagesAsBase64'])
+      ? resultMap['mrzImagesAsBase64'].map((image: { name: string; base64: string }) => ({
+          name: image.name,
+          base64: `data:image/jpeg;base64,${image.base64}`,
+        }))
+      : [];
+    this.sadlImageAsBase64 = this.convertToBase64(resultMap['sadlImageAsBase64']);
+    this.locationPoints = Array.isArray(resultMap['locationPoints']) ? resultMap['locationPoints'] : undefined;
+  }
+
+  private convertToBase64(data: string | null | undefined): string | null {
+    return data ? `data:image/jpeg;base64,${data}` : null;
   }
 }


### PR DESCRIPTION
## Summary

Synced the Barkoder wrapper (last updated 2024-07-11) with the current upstream package, **barkoder-cordova@1.6.8** (2026-03-03). Compared `www/BarkoderScanner.js` (JS bridge, exec method names) and `www/BarkoderConfig.ts` (config shapes/enums) from the published npm tarball against the wrapper's method/enum/class inventory.

Source used: `https://registry.npmjs.org/barkoder-cordova/-/barkoder-cordova-1.6.8.tgz` (unpkg redirects to app.unpkg.com, so the tarball was pulled directly from the npm registry). No usable `repo` URL exists on the `@Plugin` decorator or in `package.json`; the upstream vendor org (`BarkoderSDK`) was not referenced from the package metadata, so it was not relied on.

### Added APIs (upstream 1.6.8, absent from wrapper)
- Methods: `freezeScanning`, `unfreezeScanning`, `captureImage`, `scanImage`, `setQrDpmModeEnabled`, `setQrMicroDpmModeEnabled`, `setQrMultiPartMergeEnabled`, `setIdDocumentMasterChecksumEnabled`, `setUPCEexpandToUPCA`, `setUPCE1expandToUPCA`, `setScanningIndicatorColor/Width/Animation/AlwaysVisible`, `setCustomOption`, `setCustomOptionGlobal`, `setDynamicExposure`, `setCentricFocusAndExposure`, `setEnableComposite`, `setVideoStabilization`, `setCamera`, `setShowDuplicatesLocations`, the full AR-mode setter/getter family (`setARMode`/`getARMode`, `setAR*`/`getAR*`, `isAR*Enabled`), `configureCloseButton`, `configureFlashButton`, `configureZoomButton`, `selectVisibleBarcodes`, `setPowerSavingMode`/`getPowerSavingMode`, `getLibVersion`, `getCurrentZoomFactor`, `isDatamatrixDpmModeEnabled`, `isQrDpmModeEnabled`, `isQrMicroDpmModeEnabled`, `isQrMultiPartMergeEnabled`, `isIdDocumentMasterChecksumEnabled`, `getScanningIndicatorColorHex/Width/Animation`, `isScanningIndicatorAlwaysVisible`, `getShowDuplicatesLocations` (~85 new methods total).
- Enums: `BarkoderCameraPosition`, `BarkoderARMode`, `BarkoderAROverlayRefresh`, `BarkoderARLocationType`, `BarkoderARHeaderShowMode`, `IdDocumentMasterChecksumType`.
- New enum members: `DecodingSpeed.rigorous`, `FormattingType.sadl`, `BarcodeType.{idDocument, databar14, databarLimited, databarExpanded, postalIMB, postnet, planet, australianPost, royalMail, kix, japanesePost, maxiCode, ocrText}` (appended at the end, preserving existing ordinal values), `BarkoderResolution.{HD, FHD, UHD}` (see "Potentially breaking" below).
- Classes: `QRBarcodeConfig`, `IdDocumentBarcodeConfig`, `BarkoderARConfig`, `BarkoderResult`, `DecoderResult` (result classes match the README's documented `startScanning` callback usage).
- New fields: `BarkoderConfig.{scanningIndicatorColor, scanningIndicatorWidth, scanningIndicatorAnimation, scanningIndicatorAlwaysVisible, powerSavingMode, arConfig}`; `DekoderConfig.{idDocument, databar14, databarLimited, databarExpanded, postalIMB, postnet, planet, australianPost, royalMail, kix, japanesePost, maxiCode, ocrText}`.

### Newly deprecated (kept for compatibility, not removed)
- `setDuplicatesDelayMs` / `getDuplicatesDelayMs` — confirmed via binary search across published tarballs (1.6.3 has them, 1.6.4 does not) that these were removed upstream in **barkoder-cordova 1.6.4**; `setThresholdBetweenDuplicatesScans` / `getThresholdBetweenDuplicatesScans` (already present in the wrapper) are the replacements.
- `GeneralSettings.duplicatesDelayMs` — same upstream removal (1.6.4); the field is gone from `BarkoderConfig.ts` there. Kept the field, marked `@deprecated`.

### Bug fix
- `setDataMatrixDpmModeEnabled` called the native bridge using its own TS method name, but upstream's JS bridge has always (all published versions, including the oldest, 1.2.8) exposed this as `setDatamatrixDpmModeEnabled` (lowercase "m"). This mismatch meant the call would fail at runtime because the native/JS bridge object has no `setDataMatrixDpmModeEnabled` member. Fixed by adding `@Cordova({ methodName: 'setDatamatrixDpmModeEnabled' })` — the public TS method name is unchanged, only the underlying native call is corrected.

### Potentially breaking
- `DekoderConfig.qr`: type changed from `BarcodeConfig` to `QRBarcodeConfig` (adds `dpmMode`, `multiPartMerge`, `minLength`, `maxLength`). Upstream's `BarkoderConfig.ts` types this field as `QRBarcodeConfig`; the previous `BarcodeConfig` type (only `enabled`) didn't allow setting the DPM/multi-part-merge options that are actually read by the native side. Practically non-breaking: `QRBarcodeConfig`'s extra members are all optional, so existing `new BarcodeConfig({ enabled: true })` call sites still structurally satisfy the new type.
- `DekoderConfig.qrMicro`: type changed from `BarcodeConfig` to the wrapper's existing `DatamatrixBarcodeConfig` shape (upstream's equivalent `BarcodeConfigWithDpmMode`, structurally identical to the wrapper's pre-existing `DatamatrixBarcodeConfig`, so it was reused instead of adding a duplicate class). Same non-breaking reasoning as above.
- `BarkoderResolution`: upstream renamed `normal`/`high` to `HD`/`FHD` at some point before 1.6.3 (exact version not pinned down; the `www/BarkoderConfig.ts` file itself didn't exist yet in the oldest published version, 1.2.8, so there's no clean removal point to cite). Kept `normal`/`high` as explicit aliases (`normal = 0`, `high = 1`) of the same numeric values as `HD`/`FHD`, and added `UHD = 2` as the new resolution level. No consumer-visible break — `BarkoderResolution.normal` still equals `0`.

## Test plan
- [x] `npx eslint src/@awesome-cordova-plugins/plugins/barkoder/index.ts` — 0 errors (pre-existing `no-explicit-any` warnings only, matching the file's existing convention).
- [x] `npx tsc -p tsconfig.json --noEmit 2>&1 | grep "plugins/barkoder/"` — no output. Note: without building `@awesome-cordova-plugins/core` first, tsc reports `Cannot find module '@awesome-cordova-plugins/core'` for **every** plugin file in the repo (257 occurrences), including this one — a pre-existing environment/build-order issue unrelated to this change. Verified against a real build of `core` (`dist/@awesome-cordova-plugins/core`) that there are zero barkoder-specific type errors.
- [x] Verified every previously-exported method, interface, class, and enum member from the prior wrapper is still present under the same name (diffed exported symbols/field names/enum members programmatically).
